### PR TITLE
Reorganize module structure for better type organization

### DIFF
--- a/src/raghilda/__init__.py
+++ b/src/raghilda/__init__.py
@@ -1,3 +1,12 @@
-from ._embedding import EmbeddingProvider, EmbeddingOpenAI
+from . import embedding, store, types, chunk, chunker, document, read, scrape
 
-__all__ = ["EmbeddingProvider", "EmbeddingOpenAI"]
+__all__ = [
+    "embedding",
+    "store",
+    "types",
+    "chunk",
+    "chunker",
+    "document",
+    "read",
+    "scrape",
+]

--- a/src/raghilda/_chunker.py
+++ b/src/raghilda/_chunker.py
@@ -1,15 +1,25 @@
-from dataclasses import dataclass
 from typing import Any, List, Optional, Sequence
 import bisect
 import re
 import commonmark
 
-from ._types import Chunk, BaseChunker
+from .chunk import Chunk, MarkdownChunk
+from .document import Document
 
 
-@dataclass
-class MarkdownChunk(Chunk):
-    pass
+class BaseChunker:
+    """Base class for chunkers."""
+
+    def chunk(self, text: str) -> Sequence[Chunk]:
+        raise NotImplementedError
+
+    def chunk_document(self, doc: Document) -> Document:
+        """Chunk a document and return it with chunks attached."""
+        doc.chunks = list(self.chunk(doc.content))
+        return doc
+
+    def __call__(self, text: str) -> Sequence[Chunk]:
+        return self.chunk(text)
 
 
 class RaghildaMarkdownChunker(BaseChunker):
@@ -174,7 +184,7 @@ class RaghildaMarkdownChunker(BaseChunker):
         return [h["text"] for h in stack]
 
     # Main -----------------------------------------------------------------
-    def chunk(self, text: str) -> List[Chunk]:
+    def chunk(self, text: str) -> List[MarkdownChunk]:
         md_len = len(text)
         headings = self._heading_positions(text)
 
@@ -219,7 +229,7 @@ class RaghildaMarkdownChunker(BaseChunker):
         }
 
         # build chunks ------------------------------------------------------
-        chunks: List[Chunk] = []
+        chunks: List[MarkdownChunk] = []
         sorted_snaps = sorted(snap_table_int.values())
         for start, end in chunk_targets:
             s = snap_table_int[start]
@@ -240,7 +250,7 @@ class RaghildaMarkdownChunker(BaseChunker):
             ctx = "\n".join(ctx_lines) if len(ctx_lines) > 0 else None
 
             chunks.append(
-                Chunk(
+                MarkdownChunk(
                     text=chunk_text,
                     start_index=s,
                     end_index=e,
@@ -250,12 +260,12 @@ class RaghildaMarkdownChunker(BaseChunker):
             )
 
         # remove duplicates
-        unique: dict[int, Chunk] = {}
+        unique: dict[int, MarkdownChunk] = {}
         for c in sorted(chunks, key=lambda c: (c.start_index, -c.end_index)):
             existing = unique.get(c.start_index)
             if existing is None or c.end_index > existing.end_index:
                 unique[c.start_index] = c
-        by_end: dict[int, Chunk] = {}
+        by_end: dict[int, MarkdownChunk] = {}
         for c in sorted(unique.values(), key=lambda c: (c.end_index, c.start_index)):
             existing = by_end.get(c.end_index)
             if existing is None or c.start_index < existing.start_index:

--- a/src/raghilda/_embedding.py
+++ b/src/raghilda/_embedding.py
@@ -48,14 +48,14 @@ class EmbeddingOpenAI(EmbeddingProvider):
     Examples
     --------
     ```{python}
-    import os
-    from raghilda import EmbeddingOpenAI
-    if "OPENAI_API_KEY" in os.environ:
-        provider = EmbeddingOpenAI(model="text-embedding-3-small")
-        embeddings = provider.embed(["hello world", "testing embeddings"])
-        print(len(embeddings))
-        print(len(embeddings[0]))  # Dimension of the embedding
-        print(embeddings[0][:10])  # The embedding vector
+    #| eval: false
+    from raghilda.embedding import EmbeddingOpenAI
+
+    provider = EmbeddingOpenAI(model="text-embedding-3-small")
+    embeddings = provider.embed(["hello world", "testing embeddings"])
+    print(len(embeddings))
+    print(len(embeddings[0]))  # Dimension of the embedding
+    print(embeddings[0][:10])  # The embedding vector
     ```
     """
 

--- a/src/raghilda/_openai_store.py
+++ b/src/raghilda/_openai_store.py
@@ -1,12 +1,7 @@
 import openai
-from ._store import Store
-from ._chunker import MarkdownChunk
-from .document import (
-    Document,
-    RetrievedChunk,
-    MarkdownDocument,
-    Metric,
-)
+from ._store import BaseStore
+from .chunk import MarkdownChunk, RetrievedChunk, Metric
+from .document import Document, MarkdownDocument
 from typing import Optional, Sequence
 from dataclasses import dataclass
 
@@ -69,7 +64,7 @@ class RetrievedOpenAIMarkdownChunk(OpenAIMarkdownChunk, RetrievedChunk):
         self.metrics = metrics
 
 
-class OpenAIStore(Store):
+class OpenAIStore(BaseStore):
     @staticmethod
     def create(
         base_url: str = "https://api.openai.com/v1",

--- a/src/raghilda/_store.py
+++ b/src/raghilda/_store.py
@@ -1,14 +1,10 @@
 from abc import ABC, abstractmethod
 import os
-from ._embedding import EmbeddingProvider
-from ._chunker import MarkdownChunk, RaghildaMarkdownChunker
+from .embedding import EmbeddingProvider
+from .chunk import MarkdownChunk, RetrievedChunk, Metric
+from .chunker import RaghildaMarkdownChunker
 from .read import read_as_markdown
-from .document import (
-    Document,
-    MarkdownDocument,
-    RetrievedChunk,
-    Metric,
-)
+from .document import Document, MarkdownDocument
 from typing import Optional, Sequence, Callable
 import duckdb
 from dataclasses import dataclass, asdict
@@ -90,15 +86,15 @@ class RetrievedDuckDBMarkdownChunk(DuckDBMarkdownChunk, RetrievedChunk):
         self.metrics = metrics
 
 
-class Store(ABC):
+class BaseStore(ABC):
     @staticmethod
     @abstractmethod
-    def connect(*args, **kwargs) -> "Store":
+    def connect(*args, **kwargs) -> "BaseStore":
         pass
 
     @staticmethod
     @abstractmethod
-    def create(*args, **kwargs) -> "Store":
+    def create(*args, **kwargs) -> "BaseStore":
         pass
 
     @abstractmethod
@@ -138,7 +134,7 @@ class IndexType(StrEnum):
     HNSW = "hnsw"
 
 
-class DuckDBStore(Store):
+class DuckDBStore(BaseStore):
     @staticmethod
     def connect(
         location: str | Path = ":memory:",

--- a/src/raghilda/_types.py
+++ b/src/raghilda/_types.py
@@ -1,6 +1,14 @@
-from dataclasses import dataclass, field
-from typing import Protocol, Optional, Sequence, runtime_checkable, Union
-import uuid
+"""Protocol types for raghilda.
+
+These protocols define the interfaces for type checking compatibility
+with chunks, documents, and chunkers.
+"""
+
+from typing import TYPE_CHECKING, Protocol, Optional, Sequence, runtime_checkable
+
+if TYPE_CHECKING:
+    from .chunk import Chunk
+    from .document import Document
 
 
 @runtime_checkable
@@ -35,93 +43,8 @@ class IntoDocument(Protocol):
     def to_document(self) -> "Document": ...
 
 
-@dataclass
-class Chunk:
-    """Base chunk type for raghilda."""
-
-    text: str
-    start_index: int
-    end_index: int
-    token_count: int
-    context: Optional[str] = None
-
-    @classmethod
-    def from_any(cls, chunk: Union[ChunkLike, IntoChunk]) -> "Chunk":
-        """Convert any chunk-like or IntoChunk object to a raghilda Chunk."""
-        if isinstance(chunk, IntoChunk):
-            if not callable(chunk.to_chunk):
-                raise TypeError(
-                    f"{type(chunk).__name__}.to_chunk must be a method, not {type(chunk.to_chunk).__name__}"
-                )
-            result = chunk.to_chunk()
-            if not isinstance(result, Chunk):
-                raise TypeError(
-                    f"{type(chunk).__name__}.to_chunk() must return a Chunk, got {type(result).__name__}"
-                )
-            return result
-        elif isinstance(chunk, ChunkLike):
-            return cls(
-                text=chunk.text,
-                start_index=chunk.start_index,
-                end_index=chunk.end_index,
-                token_count=chunk.token_count,
-                context=getattr(chunk, "context", None),
-            )
-        raise TypeError(f"Cannot convert {type(chunk).__name__} to Chunk")
-
-
-def _generate_doc_id() -> str:
-    return f"doc_{uuid.uuid4().hex}"
-
-
-@dataclass
-class Document:
-    """Base document type for raghilda."""
-
-    content: str
-    id: str = field(default_factory=_generate_doc_id)
-    chunks: Optional[list[Chunk]] = None
-
-    @classmethod
-    def from_any(cls, doc: Union[DocumentLike, IntoDocument]) -> "Document":
-        """Convert any document-like or IntoDocument object to a raghilda Document."""
-        if isinstance(doc, IntoDocument):
-            if not callable(doc.to_document):
-                raise TypeError(
-                    f"{type(doc).__name__}.to_document must be a method, not {type(doc.to_document).__name__}"
-                )
-            result = doc.to_document()
-            if not isinstance(result, Document):
-                raise TypeError(
-                    f"{type(doc).__name__}.to_document() must return a Document, got {type(result).__name__}"
-                )
-            return result
-        elif isinstance(doc, DocumentLike):
-            chunks = None
-            if doc.chunks is not None:
-                chunks = [Chunk.from_any(c) for c in doc.chunks]
-            doc_id = getattr(doc, "id", None) or _generate_doc_id()
-            return cls(content=doc.content, id=doc_id, chunks=chunks)
-        raise TypeError(f"Cannot convert {type(doc).__name__} to Document")
-
-
 @runtime_checkable
 class ChunkerLike(Protocol):
     """Any chunker-like object (chonkie, raghilda, or custom)."""
 
-    def chunk(self, text: str) -> list[Chunk]: ...
-
-
-class BaseChunker:
-    """Base class for chunkers."""
-
-    def chunk(self, text: str) -> list[Chunk]:
-        raise NotImplementedError
-
-    def chunk_document(self, doc: Document) -> Document:
-        """Chunk a document and return it with chunks attached."""
-        doc.chunks = self.chunk(doc.content)
-        return doc
-
-    def __call__(self, text: str) -> list[Chunk]:
-        return self.chunk(text)
+    def chunk(self, text: str) -> Sequence["Chunk"]: ...

--- a/src/raghilda/chunk.py
+++ b/src/raghilda/chunk.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass, field
+from typing import Optional, Union
+from .types import ChunkLike, IntoChunk
+
+__all__ = ["Chunk", "MarkdownChunk", "Metric", "RetrievedChunk"]
+
+
+@dataclass
+class Chunk:
+    """Base chunk type for raghilda."""
+
+    text: str
+    start_index: int
+    end_index: int
+    token_count: int
+    context: Optional[str] = None
+
+    @classmethod
+    def from_any(cls, chunk: Union[ChunkLike, IntoChunk]) -> "Chunk":
+        """Convert any chunk-like or IntoChunk object to a raghilda Chunk."""
+        if isinstance(chunk, IntoChunk):
+            if not callable(chunk.to_chunk):
+                raise TypeError(
+                    f"{type(chunk).__name__}.to_chunk must be a method, not {type(chunk.to_chunk).__name__}"
+                )
+            result = chunk.to_chunk()
+            if not isinstance(result, Chunk):
+                raise TypeError(
+                    f"{type(chunk).__name__}.to_chunk() must return a Chunk, got {type(result).__name__}"
+                )
+            return result
+        elif isinstance(chunk, ChunkLike):
+            return cls(
+                text=chunk.text,
+                start_index=chunk.start_index,
+                end_index=chunk.end_index,
+                token_count=chunk.token_count,
+                context=getattr(chunk, "context", None),
+            )
+        raise TypeError(f"Cannot convert {type(chunk).__name__} to Chunk")
+
+
+@dataclass
+class MarkdownChunk(Chunk):
+    pass
+
+
+@dataclass
+class Metric:
+    name: str
+    value: float
+
+
+@dataclass
+class RetrievedChunk(Chunk):
+    metrics: list[Metric] = field(default_factory=list)

--- a/src/raghilda/chunker.py
+++ b/src/raghilda/chunker.py
@@ -1,3 +1,4 @@
-from ._chunker import RaghildaMarkdownChunker, MarkdownChunk
+from ._chunker import BaseChunker, RaghildaMarkdownChunker
+from .chunk import MarkdownChunk
 
-__all__ = ["RaghildaMarkdownChunker", "MarkdownChunk"]
+__all__ = ["BaseChunker", "RaghildaMarkdownChunker", "MarkdownChunk"]

--- a/src/raghilda/document.py
+++ b/src/raghilda/document.py
@@ -1,6 +1,46 @@
 from dataclasses import dataclass, field
 from typing import Optional, Union
-from ._types import Chunk, Document, DocumentLike, IntoDocument
+import uuid
+
+from .types import DocumentLike, IntoDocument
+from .chunk import Chunk
+
+__all__ = ["Document", "MarkdownDocument"]
+
+
+def _generate_doc_id() -> str:
+    return f"doc_{uuid.uuid4().hex}"
+
+
+@dataclass
+class Document:
+    """Base document type for raghilda."""
+
+    content: str
+    id: str = field(default_factory=_generate_doc_id)
+    chunks: Optional[list[Chunk]] = None
+
+    @classmethod
+    def from_any(cls, doc: Union[DocumentLike, IntoDocument]) -> "Document":
+        """Convert any document-like or IntoDocument object to a raghilda Document."""
+        if isinstance(doc, IntoDocument):
+            if not callable(doc.to_document):
+                raise TypeError(
+                    f"{type(doc).__name__}.to_document must be a method, not {type(doc.to_document).__name__}"
+                )
+            result = doc.to_document()
+            if not isinstance(result, Document):
+                raise TypeError(
+                    f"{type(doc).__name__}.to_document() must return a Document, got {type(result).__name__}"
+                )
+            return result
+        elif isinstance(doc, DocumentLike):
+            chunks = None
+            if doc.chunks is not None:
+                chunks = [Chunk.from_any(c) for c in doc.chunks]
+            doc_id = getattr(doc, "id", None) or _generate_doc_id()
+            return cls(content=doc.content, id=doc_id, chunks=chunks)
+        raise TypeError(f"Cannot convert {type(doc).__name__} to Document")
 
 
 @dataclass
@@ -19,14 +59,3 @@ class MarkdownDocument(Document):
             chunks=base.chunks,
             origin=getattr(doc, "origin", origin),
         )
-
-
-@dataclass
-class Metric:
-    name: str
-    value: float
-
-
-@dataclass
-class RetrievedChunk(Chunk):
-    metrics: list[Metric] = field(default_factory=list)

--- a/src/raghilda/embedding.py
+++ b/src/raghilda/embedding.py
@@ -1,0 +1,3 @@
+from ._embedding import EmbeddingProvider, EmbeddingOpenAI
+
+__all__ = ["EmbeddingProvider", "EmbeddingOpenAI"]

--- a/src/raghilda/read.py
+++ b/src/raghilda/read.py
@@ -46,6 +46,7 @@ def read_as_markdown(
     Examples
     --------
     ```{python}
+    #| eval: false
     from raghilda.read import read_as_markdown
 
     # Read from a local file

--- a/src/raghilda/scrape.py
+++ b/src/raghilda/scrape.py
@@ -82,10 +82,10 @@ def find_links(
         Additional keyword arguments forwarded to :func:`requests.Session.get`
         (and ``head`` during validation) when fetching HTTP resources.
 
-    Yields
-    ------
-    str
-        Absolute link targets, deduplicated and ordered as discovered.
+    Returns
+    -------
+    Iterator[str]
+        Yields absolute link targets, deduplicated and ordered as discovered.
     """
     if isinstance(x, (str, Path)):
         entries: list[str] = [str(x)]

--- a/src/raghilda/store.py
+++ b/src/raghilda/store.py
@@ -1,4 +1,4 @@
-from ._store import Store, DuckDBStore
+from ._store import BaseStore, DuckDBStore
 from ._openai_store import OpenAIStore
 
-__all__ = ["Store", "DuckDBStore", "OpenAIStore"]
+__all__ = ["BaseStore", "DuckDBStore", "OpenAIStore"]

--- a/src/raghilda/types.py
+++ b/src/raghilda/types.py
@@ -1,29 +1,18 @@
-"""Public types for raghilda.
+"""Protocol types for raghilda.
 
-This module exports the core types and protocols for working with chunks,
-documents, and chunkers in raghilda.
+This module exports the protocol types for type checking compatibility
+with chunks, documents, and chunkers.
 """
 
 from ._types import (
-    # Concrete types
-    Chunk,
-    Document,
-    BaseChunker,
-    # Protocols for accepting compatible types
     ChunkLike,
     DocumentLike,
     ChunkerLike,
-    # Protocols for custom conversion
     IntoChunk,
     IntoDocument,
 )
 
 __all__ = [
-    # Concrete types
-    "Chunk",
-    "Document",
-    "BaseChunker",
-    # Protocols
     "ChunkLike",
     "DocumentLike",
     "ChunkerLike",

--- a/tests/test_chonkie_compat.py
+++ b/tests/test_chonkie_compat.py
@@ -6,9 +6,10 @@ import pytest
 chonkie = pytest.importorskip("chonkie")
 
 from chonkie.types import Chunk as ChonkieChunk, Document as ChonkieDocument  # noqa: E402
-from raghilda._types import Chunk, Document, ChunkLike, DocumentLike  # noqa: E402
-from raghilda._store import DuckDBStore  # noqa: E402
-from raghilda.document import MarkdownDocument  # noqa: E402
+from raghilda.chunk import Chunk  # noqa: E402
+from raghilda.document import Document, MarkdownDocument  # noqa: E402
+from raghilda.types import ChunkLike, DocumentLike  # noqa: E402
+from raghilda.store import DuckDBStore  # noqa: E402
 
 
 class TestChonkieChunkCompatibility:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,10 +1,5 @@
-from raghilda.document import (
-    RetrievedChunk,
-    Metric,
-)
-
-from raghilda._chunker import Chunk, MarkdownChunk
-from raghilda._store import RetrievedDuckDBMarkdownChunk
+from raghilda.chunk import Chunk, MarkdownChunk, RetrievedChunk, Metric
+from raghilda._store import RetrievedDuckDBMarkdownChunk  # internal implementation
 
 
 def test_retrieved_chunk():

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-from raghilda import EmbeddingOpenAI
+from raghilda.embedding import EmbeddingOpenAI
 
 
 class TestEmbeddingOpenAI:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2,13 +2,10 @@ import os
 import pytest
 from raghilda.store import DuckDBStore, OpenAIStore
 from raghilda.scrape import find_links
-from raghilda.document import (
-    MarkdownDocument,
-    RetrievedChunk,
-)
-from raghilda._chunker import MarkdownChunk
-from raghilda._store import RetrievedDuckDBMarkdownChunk
-from raghilda import EmbeddingOpenAI
+from raghilda.document import MarkdownDocument
+from raghilda.chunk import MarkdownChunk, RetrievedChunk
+from raghilda._store import RetrievedDuckDBMarkdownChunk  # internal implementation
+from raghilda.embedding import EmbeddingOpenAI
 
 
 class TestDuckDBStore:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,11 +1,7 @@
 import pytest
-from raghilda._types import (
-    Chunk,
-    ChunkLike,
-    IntoChunk,
-    Document,
-    DocumentLike,
-)
+from raghilda.chunk import Chunk
+from raghilda.document import Document
+from raghilda.types import ChunkLike, DocumentLike, IntoChunk
 
 
 class TestChunkLikeProtocol:


### PR DESCRIPTION
## Summary

- Create dedicated `chunk` module with Chunk, MarkdownChunk, RetrievedChunk, Metric
- Create dedicated `embedding` module with EmbeddingProvider, EmbeddingOpenAI
- Move Document and MarkdownDocument definitions to `document` module
- Move BaseChunker to `_chunker` module alongside RaghildaMarkdownChunker
- Rename Store to BaseStore for consistency with BaseChunker
- Simplify `_types` module to only contain protocol definitions
- Update `types` module to export only protocol types
- Update all cross-module imports to use public modules instead of internal ones

## New module structure

| Module | Contents |
|--------|----------|
| `raghilda.chunk` | `Chunk`, `MarkdownChunk`, `RetrievedChunk`, `Metric` |
| `raghilda.document` | `Document`, `MarkdownDocument` |
| `raghilda.embedding` | `EmbeddingProvider`, `EmbeddingOpenAI` |
| `raghilda.store` | `BaseStore`, `DuckDBStore`, `OpenAIStore` |
| `raghilda.chunker` | `BaseChunker`, `RaghildaMarkdownChunker`, `MarkdownChunk` |
| `raghilda.types` | `ChunkLike`, `DocumentLike`, `ChunkerLike`, `IntoChunk`, `IntoDocument` |
| `raghilda.read` | `read_as_markdown` |
| `raghilda.scrape` | `find_links` |

## Breaking changes

- `Store` renamed to `BaseStore`
- `EmbeddingProvider` and `EmbeddingOpenAI` now in `raghilda.embedding` (no longer re-exported from main package)
- `Chunk`, `Document`, `BaseChunker` moved to their respective domain modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)