### PR TITLE
Fix DuckDB cursor thread safety issue causing commit() to hang

### DIFF
--- a/src/raghilda/_duckdb_store.py
+++ b/src/raghilda/_duckdb_store.py
@@ -2,6 +2,7 @@ from ._store import BaseStore
 from collections.abc import Sized
 import json
 import os
+import threading
 from .embedding import EmbeddingProvider, EmbedInputType, embedding_from_config
 from .chunk import MarkdownChunk, RetrievedChunk, Metric
 from .chunker import MarkdownChunker
@@ -400,6 +401,7 @@ class DuckDBStore(BaseStore):
     ):
         self.con = con
         self.metadata = metadata
+        self._db_lock = threading.Lock()
 
     def insert(
         self,
@@ -558,25 +560,24 @@ class DuckDBStore(BaseStore):
         for column in self.metadata.attributes_schema:
             chunks[column] = [row[column] for row in resolved_chunk_attributes]
 
-        # local cursor is used so we can use multiple threads
-        # see https://duckdb.org/docs/stable/guides/python/multiple_threads.html
-        cursor = self.con.cursor()
-        try:
-            cursor.begin()
-            doc.rename(
-                columns={"content": "text", "id": "doc_id"}, inplace=True
-            )  # content -> text
-            chunks["doc_id"] = [doc["doc_id"][0]] * len(chunks)
+        doc.rename(
+            columns={"content": "text", "id": "doc_id"}, inplace=True
+        )  # content -> text
+        chunks["doc_id"] = [doc["doc_id"][0]] * len(chunks)
 
-            _duckdb_append(cursor, "documents", doc)
-            _duckdb_append(cursor, "embeddings", chunks)
-            cursor.commit()
-        except Exception as e:
+        # DuckDB connections are not thread-safe. Use a lock to serialize all
+        # DB operations. Embedding runs outside the lock for parallelism.
+        with self._db_lock:
             try:
-                cursor.rollback()
-            except Exception:
-                pass
-            finally:
+                self.con.begin()
+                _duckdb_append(self.con, "documents", doc)
+                _duckdb_append(self.con, "embeddings", chunks)
+                self.con.commit()
+            except Exception as e:
+                try:
+                    self.con.rollback()
+                except Exception:
+                    pass
                 raise e
 
     def retrieve(
@@ -742,18 +743,17 @@ class DuckDBStore(BaseStore):
         LIMIT {top_k}
         """
 
-        cursor = self.con.cursor()
+        with self._db_lock:
+            result = self.con.execute(sql)
+            rows = result.fetchall()
 
-        cursor.execute(sql)
-        results = cursor.fetchall()
+            if result.description is None:
+                raise RuntimeError("Failed get result description.")
 
-        if cursor.description is None:
-            raise RuntimeError("Failed get cursor description.")
-
-        columns = [desc[0] for desc in cursor.description]
+            columns = [desc[0] for desc in result.description]
 
         output: list[RetrievedDuckDBMarkdownChunk] = []
-        for chunk in results:
+        for chunk in rows:
             chunk_dict = dict(zip(columns, chunk))
             name, value = chunk_dict.pop("metric_name"), chunk_dict.pop("metric_value")
             attribute_values: dict[str, AttributeValue] = {}
@@ -846,27 +846,26 @@ class DuckDBStore(BaseStore):
         LIMIT $top_k
         """
 
-        cursor = self.con.cursor()
+        with self._db_lock:
+            result = self.con.execute(
+                sql,
+                {
+                    "query": query,
+                    "top_k": top_k,
+                    "k": k,
+                    "b": b,
+                    "conjunctive": conjunctive,
+                },
+            )
+            rows = result.fetchall()
 
-        cursor.execute(
-            sql,
-            {
-                "query": query,
-                "top_k": top_k,
-                "k": k,
-                "b": b,
-                "conjunctive": conjunctive,
-            },
-        )
-        results = cursor.fetchall()
+            if result.description is None:
+                raise RuntimeError("Failed get result description.")
 
-        if cursor.description is None:
-            raise RuntimeError("Failed get cursor description.")
-
-        columns = [desc[0] for desc in cursor.description]
+            columns = [desc[0] for desc in result.description]
 
         output: list[RetrievedDuckDBMarkdownChunk] = []
-        for chunk in results:
+        for chunk in rows:
             chunk_dict = dict(zip(columns, chunk))
             name, value = chunk_dict.pop("metric_name"), chunk_dict.pop("metric_value")
             attribute_values: dict[str, AttributeValue] = {}


### PR DESCRIPTION
## Summary

- Fixes thread safety issues with DuckDB connection access
- Adds `_db_lock` to serialize all database operations (reads and writes)
- Uses the connection directly instead of creating cursors
- Keeps embedding operations outside the lock for parallelism

## Problem

When using `store.ingest()` with `ThreadPoolExecutor`, DuckDB operations could hang or behave unpredictably because DuckDB connections are not thread-safe.

## Root Cause

DuckDB connections should not be accessed concurrently from multiple threads. The previous implementation:
1. Created cursors in worker threads which could hang on `commit()`
2. Had no synchronization for read operations (`retrieve_vss`, `retrieve_bm25`)

## Solution

According to the [DuckDB documentation on multiple threads](https://duckdb.org/docs/stable/guides/python/multiple_threads), it is technically possible to use DuckDB from multiple threads by creating separate cursors per thread. However, this approach complicates the implementation and we encountered hangs on `commit()` when cursors were created in worker threads.

Instead, we use a simpler approach with a lock to serialize all DB operations:

1. Add a `_db_lock` (threading.Lock) to serialize all DB operations
2. Use the connection directly (`self.con.execute()`) instead of creating cursors
3. Apply the lock to both writes and reads
4. Keep embedding operations (external API calls) outside the lock for parallelism

```python
# Write operations
with self._db_lock:
    self.con.begin()
    _duckdb_append(self.con, "documents", doc)
    _duckdb_append(self.con, "embeddings", chunks)
    self.con.commit()

# Read operations
with self._db_lock:
    result = self.con.execute(sql)
    rows = result.fetchall()
```

---

This is a port of #27 to the current main branch after recent refactoring.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)