### PR TITLE
Reduce default ingest threads from CPU count to 4

### DIFF
--- a/src/raghilda/_chroma_store.py
+++ b/src/raghilda/_chroma_store.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 import importlib
 import json
-import os
 from pathlib import Path
 from collections.abc import Sized
 from typing import (
@@ -542,7 +541,7 @@ class ChromaDBStore(BaseStore):
             and processed with read_as_markdown followed by MarkdownChunker.
         num_workers
             The number of worker threads to use for parallel ingestion.
-            If None, defaults to the number of CPU cores.
+            If None, defaults to 4 to avoid API rate limiting.
         progress
             Whether to display a progress bar during ingestion. Default is True.
             The progress bar shows the total count only if items has a known length
@@ -588,7 +587,7 @@ class ChromaDBStore(BaseStore):
         ```
         """
         if num_workers is None:
-            num_workers = os.cpu_count() or 1
+            num_workers = 4
 
         if prepare is None:
             chunker = MarkdownChunker()

--- a/src/raghilda/_duckdb_store.py
+++ b/src/raghilda/_duckdb_store.py
@@ -443,7 +443,7 @@ class DuckDBStore(BaseStore):
             and processed with read_as_markdown followed by MarkdownChunker.
         num_workers
             The number of worker threads to use for parallel ingestion.
-            If None, defaults to the number of CPU cores.
+            If None, defaults to 4 to avoid API rate limiting.
         progress
             Whether to display a progress bar during ingestion. Default is True.
             The progress bar shows the total count only if items has a known length
@@ -489,7 +489,7 @@ class DuckDBStore(BaseStore):
         ```
         """
         if num_workers is None:
-            num_workers = os.cpu_count() or 1
+            num_workers = 4
 
         if prepare is None:
             chunker = MarkdownChunker()


### PR DESCRIPTION
## Summary
- Reduce default `num_workers` in `ingest()` from `os.cpu_count()` to 4 for both DuckDB and Chroma backends
- Prevents API rate limiting issues when generating embeddings in parallel
- Updated docstrings to document the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)