### PR TITLE
Set User-Agent header for HTTP requests

### DIFF
--- a/src/raghilda/read.py
+++ b/src/raghilda/read.py
@@ -1,6 +1,9 @@
 import re
 import warnings
 from typing import Optional
+
+import requests as _requests
+
 from .document import MarkdownDocument
 
 with warnings.catch_warnings():
@@ -75,8 +78,6 @@ def read_as_markdown(
 
     return MarkdownDocument(origin=uri, content=md)
 
-
-import requests as _requests
 
 _session = _requests.Session()
 _session.headers.update({"User-Agent": "raghilda"})


### PR DESCRIPTION
## Summary

- Sets a `User-Agent: raghilda` header on MarkItDown's requests session
- Fixes 403 Forbidden errors when fetching URLs from sites like Wikipedia that reject requests without a User-Agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)