### PR TITLE
refactor(duckdb): remove pandas dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11, <3.14"
 dependencies = [
     "duckdb>=1.3.2",
     "openai>=1.104.2",
-    "pandas>=2.3.2",
     "requests>=2.32.5",
     "commonmark>=0.9.1",
     "markitdown>=0.1.3",

--- a/src/raghilda/_duckdb_store.py
+++ b/src/raghilda/_duckdb_store.py
@@ -13,7 +13,6 @@ import duckdb
 from dataclasses import dataclass, asdict
 import logging
 from pathlib import Path
-import pandas as pd
 from enum import StrEnum
 from concurrent.futures import ThreadPoolExecutor
 from tqdm import tqdm
@@ -481,21 +480,22 @@ class DuckDBStore(BaseStore):
                     text=existing["text"],
                 )
                 doc_row["doc_id"] = doc_id
-                chunk_rows["doc_id"] = [doc_id] * len(chunk_rows)
+                for chunk_row in chunk_rows:
+                    chunk_row["doc_id"] = doc_id
 
             try:
                 self.con.begin()
                 if action == "replaced":
                     self.con.execute(
                         "DELETE FROM embeddings WHERE doc_id = ?",
-                        [doc_row["doc_id"][0]],
+                        [doc_row["doc_id"]],
                     )
                     self.con.execute(
                         "UPDATE documents SET text = ? WHERE doc_id = ?",
-                        [doc_row["text"][0], doc_row["doc_id"][0]],
+                        [doc_row["text"], doc_row["doc_id"]],
                     )
                 else:
-                    _duckdb_append(self.con, "documents", doc_row)
+                    _duckdb_append(self.con, "documents", [doc_row])
                 _duckdb_append(self.con, "embeddings", chunk_rows)
                 self.con.commit()
             except Exception:
@@ -505,7 +505,7 @@ class DuckDBStore(BaseStore):
                     pass
                 raise
 
-            result_doc_id = str(doc_row["doc_id"][0])
+            result_doc_id = str(doc_row["doc_id"])
             current_document = self._load_document_snapshot(
                 doc_id=result_doc_id,
                 origin=document.origin,
@@ -620,17 +620,15 @@ class DuckDBStore(BaseStore):
     def _prepare_chunked_document_rows(
         self,
         chunked_doc: MarkdownDocument,
-    ) -> tuple[pd.DataFrame, pd.DataFrame]:
-        doc = pd.DataFrame(
-            [
-                {
-                    "doc_id": chunked_doc.origin,
-                    "origin": chunked_doc.origin,
-                    "text": chunked_doc.content,
-                }
-            ]
-        )
-        chunks = pd.DataFrame(asdict(chunk) for chunk in chunked_doc.chunks or [])
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        assert chunked_doc.chunks is not None
+
+        doc = {
+            "doc_id": chunked_doc.origin,
+            "origin": chunked_doc.origin,
+            "text": chunked_doc.content,
+        }
+        chunks = [asdict(chunk) for chunk in chunked_doc.chunks]
 
         resolved_chunk_attributes: list[dict[str, AttributeValue]] = []
         for chunk in chunked_doc.chunks or []:
@@ -642,32 +640,35 @@ class DuckDBStore(BaseStore):
                 )
             )
 
+        embedded_chunks = None
         if self.metadata.embed is not None:
-            chunks["embedding"] = self.metadata.embed.embed(
-                chunks.text.tolist(), EmbedInputType.DOCUMENT
+            embedded_chunks = self.metadata.embed.embed(
+                [chunk["text"] for chunk in chunks], EmbedInputType.DOCUMENT
             )
-        else:
-            chunks.drop(columns=["embedding"], inplace=True, errors="ignore")
 
-        # Remove token_count since it's not stored in the database
-        if "token_count" in chunks.columns:
-            chunks.drop(columns=["token_count"], inplace=True)
-        if "text" in chunks.columns:
-            chunks.rename(columns={"text": "chunk_text"}, inplace=True)
-        # User attributes are represented as dedicated columns in embeddings.
-        if "attributes" in chunks.columns:
-            chunks.drop(columns=["attributes"], inplace=True)
-        # Drop non-embedding source fields before writing to embeddings.
-        chunks.drop(
-            columns=["id", "origin", "chunk_ids"], inplace=True, errors="ignore"
-        )
+        chunk_rows: list[dict[str, Any]] = []
+        for index, chunk_data in enumerate(chunks):
+            row = dict(chunk_data)
 
-        for column in self.metadata.attributes_schema:
-            chunks[column] = [row[column] for row in resolved_chunk_attributes]
+            row.pop("token_count", None)
+            row.pop("attributes", None)
+            row["chunk_text"] = row.pop("text", None)
+            row.pop("id", None)
+            row.pop("origin", None)
+            row.pop("chunk_ids", None)
 
-        chunks["doc_id"] = [doc["doc_id"][0]] * len(chunks)
+            if embedded_chunks is not None:
+                row["embedding"] = embedded_chunks[index]
+            else:
+                row.pop("embedding", None)
 
-        return doc, chunks
+            for column in self.metadata.attributes_schema:
+                row[column] = resolved_chunk_attributes[index][column]
+
+            row["doc_id"] = doc["doc_id"]
+            chunk_rows.append(row)
+
+        return doc, chunk_rows
 
     def _get_existing_documents_by_origin(self, origin: str) -> list[dict[str, str]]:
         rows = self.con.execute(
@@ -1341,18 +1342,20 @@ def _table_columns(con: duckdb.DuckDBPyConnection, *, table: str) -> set[str]:
     return {str(row[1]) for row in rows}
 
 
-def _duckdb_append(con: duckdb.DuckDBPyConnection, table: str, data):
-    try:
-        con.register(f"tmp_data_{table}", data)
-        column_list = ", ".join(_quote_identifier(col) for col in data.columns)
-        con.execute(
-            f"INSERT INTO {table} ({column_list}) SELECT * FROM tmp_data_{table}"
-        )
-    finally:
-        try:
-            con.unregister(f"tmp_data_{table}")
-        except Exception:
-            pass
+def _duckdb_append(
+    con: duckdb.DuckDBPyConnection, table: str, rows: Sequence[Mapping[str, Any]]
+) -> None:
+    if not rows:
+        return
+
+    columns = list(rows[0])
+    values = [tuple(row[column] for column in columns) for row in rows]
+    column_list = ", ".join(_quote_identifier(column) for column in columns)
+    placeholders = ", ".join("?" for _ in columns)
+    con.executemany(
+        f"INSERT INTO {_quote_identifier(table)} ({column_list}) VALUES ({placeholders})",
+        values,
+    )
 
 
 def _quote_identifier(identifier: str) -> str:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,6 +1,10 @@
 import os
 import hashlib
 import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Annotated, Any, cast
 import duckdb
@@ -3053,3 +3057,53 @@ def test_connect_fails_fast_when_embeddings_table_lacks_chunk_text(tmp_path):
         match="table 'embeddings' missing required columns: chunk_text",
     ):
         DuckDBStore.connect(str(db_path))
+
+
+def test_duckdb_store_does_not_require_pandas():
+    repo_root = Path(__file__).resolve().parents[1]
+    src_path = repo_root / "src"
+    script = textwrap.dedent(
+        """
+        import builtins
+
+        original_import = builtins.__import__
+
+        def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "pandas" or name.startswith("pandas."):
+                raise ModuleNotFoundError("No module named 'pandas'")
+            return original_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = blocked_import
+
+        from raghilda.chunk import MarkdownChunk
+        from raghilda.document import MarkdownDocument
+        from raghilda.store import DuckDBStore
+
+        store = DuckDBStore.create(location=":memory:", embed=None, overwrite=True)
+        doc = MarkdownDocument(origin="test", content="hello world")
+        doc.chunks = [
+            MarkdownChunk(
+                start_index=0,
+                end_index=5,
+                text="hello",
+                token_count=5,
+            )
+        ]
+        store.upsert(doc)
+        assert store.size() == 1
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = (
+        f"{src_path}{os.pathsep}{env['PYTHONPATH']}"
+        if env.get("PYTHONPATH")
+        else str(src_path)
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        cwd=repo_root,
+        env=env,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- remove `pandas` from package dependencies
- rewrite DuckDB row preparation and insert logic to use plain Python dict/list rows
- keep upsert/replace behavior equivalent while removing DataFrame-specific indexing

## Public-facing changes
- `DuckDBStore` no longer requires `pandas` to be installed
- package installation no longer pulls `pandas` as a direct dependency

## Internal changes
- `_prepare_chunked_document_rows()` now returns `dict` + `list[dict]` instead of DataFrames
- `_duckdb_append()` now uses `executemany` with parameterized inserts
- replacement upsert path now updates `doc_id` and document fields with scalar values
- add regression test that blocks `pandas` imports and verifies `DuckDBStore` still works

## Testing
- `./.venv/bin/pytest tests/test_store.py -k "duckdb and not OpenAIStore" -q`
