### PR TITLE
Fail fast on embedding/chunk count mismatches in DuckDBStore

### DIFF
--- a/src/raghilda/_duckdb_store.py
+++ b/src/raghilda/_duckdb_store.py
@@ -645,6 +645,11 @@ class DuckDBStore(BaseStore):
             embedded_chunks = self.metadata.embed.embed(
                 [chunk["text"] for chunk in chunks], EmbedInputType.DOCUMENT
             )
+            if len(embedded_chunks) != len(chunks):
+                raise ValueError(
+                    "Embedding provider must return exactly one embedding per chunk "
+                    f"(got {len(embedded_chunks)} embeddings for {len(chunks)} chunks)"
+                )
 
         chunk_rows: list[dict[str, Any]] = []
         for index, chunk_data in enumerate(chunks):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -338,6 +338,43 @@ class TestDuckDBStore:
         assert second.document.attributes == {"tenant": "docs"}
         assert embed.calls == calls_after_create + 1
 
+    def test_insert_fails_when_embed_count_exceeds_chunk_count(self):
+        class ExtraEmbeddingRows(EmbeddingProvider):
+            def embed(
+                self,
+                x,
+                input_type: EmbedInputType = EmbedInputType.DOCUMENT,
+            ):
+                return [[1.0] for _ in range(len(x) + 1)]
+
+            def get_config(self):
+                return {"type": "ExtraEmbeddingRows"}
+
+            @classmethod
+            def from_config(cls, config):
+                return cls()
+
+        store = DuckDBStore.create(
+            location=":memory:",
+            embed=ExtraEmbeddingRows(),
+            overwrite=True,
+            name="insert_embed_count_mismatch",
+        )
+        doc = MarkdownDocument(origin="doc-1", content="hello world")
+        doc.chunks = [
+            MarkdownChunk(
+                start_index=0,
+                end_index=len(doc.content),
+                text=doc.content,
+                token_count=len(doc.content),
+            )
+        ]
+
+        with pytest.raises(
+            ValueError, match="must return exactly one embedding per chunk"
+        ):
+            store.upsert(doc)
+
     def test_insert_requires_origin(self):
         store = DuckDBStore.create(
             location=":memory:",


### PR DESCRIPTION
## Summary
- add a fail-fast check in `DuckDBStore.upsert` to ensure embedding providers return exactly one embedding per chunk
- raise a clear `ValueError` when the embedding count does not match the chunk count
- add a regression test covering the mismatch case

## Public-facing changes
- `DuckDBStore.upsert` now raises `ValueError` if an embedding provider returns a different number of embeddings than input chunks

## Internal-only changes
- added one regression test in `tests/test_store.py` for the embedding count mismatch path
