### PR TITLE
fix(chroma): serialize collection access to prevent telemetry race

### DIFF
--- a/src/raghilda/_chroma_store.py
+++ b/src/raghilda/_chroma_store.py
@@ -490,6 +490,8 @@ class ChromaDBStore(BaseStore):
         self._origin_lock_ref_counts: dict[str, int] = {}
         self._origin_locks_guard = threading.Lock()
         self._chunk_id_lock = threading.Lock()
+        # Temporary workaround for ChromaDB's non-thread-safe telemetry batching.
+        # See https://github.com/chroma-core/chroma/issues/6512
         self._collection_lock = threading.Lock()
         self._next_chunk_id: Optional[int] = None
 


### PR DESCRIPTION
## Summary

- ChromaDB's internal posthog telemetry (`batched_events` dict) is not thread-safe, causing `KeyError` when multiple threads call collection methods concurrently during `ingest()`. See https://github.com/chroma-core/chroma/issues/6512
- Adds a `_collection_lock` (`threading.Lock`) that serializes all `self.collection.*` calls (`.get`, `.upsert`, `.delete`, `.query`) to work around the upstream bug
- Existing locks (`_origin_lock`, `_chunk_id_lock`) are preserved as they protect different invariants (read-modify-write sequences and ID allocation, respectively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)