### PR TITLE
fix(duckdb): load vss extension on connect when HNSW indexes exist

### DIFF
--- a/src/raghilda/_duckdb_store.py
+++ b/src/raghilda/_duckdb_store.py
@@ -204,6 +204,7 @@ class DuckDBStore(BaseStore):
         """
         con = duckdb.connect(database=location, read_only=read_only)
         _check_is_raghilda_con(con)
+        _load_extensions_for_existing_indexes(con)
 
         row = con.execute(
             "SELECT name, title, embed_config, attributes_schema_json FROM metadata"
@@ -1262,6 +1263,19 @@ def _check_is_raghilda_con(con: duckdb.DuckDBPyConnection):
 
     if "metadata" not in tables:
         raise ValueError("Not a valid Raghilda database connection")
+
+
+def _load_extensions_for_existing_indexes(con: duckdb.DuckDBPyConnection) -> None:
+    """Load DuckDB extensions required by any indexes that already exist.
+
+    When reconnecting to a database that has HNSW indexes (from the ``vss``
+    extension), the extension must be loaded before any writes to the indexed
+    table, otherwise DuckDB raises *"unknown index type 'HNSW'"*.
+    """
+    rows = con.execute("SELECT sql FROM duckdb_indexes()").fetchall()
+    has_hnsw = any("USING HNSW" in (row[0] or "") for row in rows)
+    if has_hnsw:
+        con.execute("INSTALL vss; LOAD vss;")
 
 
 def _validate_required_schema(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -3029,6 +3029,42 @@ def test_connect(tmp_path):
     assert results[0].text == "hello"
 
 
+def test_upsert_after_hnsw_index_on_reconnect(tmp_path):
+    """Upserting after reconnecting to a DB with HNSW indexes must work.
+
+    Regression test: ``connect()`` did not load the ``vss`` extension, so
+    DuckDB raised "unknown index type 'HNSW'" on INSERT into a table that
+    already carried HNSW indexes.
+    """
+    db_path = tmp_path / "hnsw_upsert.db"
+    embed = CountingEmbedding()
+
+    # Phase 1: create store, insert a document, build HNSW index, close.
+    store = DuckDBStore.create(
+        location=str(db_path),
+        embed=embed,
+        name="hnsw_test",
+        title="HNSW Upsert Test",
+    )
+    doc1 = MarkdownDocument(origin="doc1", content="alpha beta gamma")
+    doc1.chunks = [_get_markdown_chunk(doc1, start=0, end=5)]
+    store.upsert(doc1)
+    store.build_index("hnsw")
+    store.con.close()
+
+    # Phase 2: reconnect and upsert a new document.
+    store2 = DuckDBStore.connect(str(db_path))
+    # Restore a working embedding provider (CountingEmbedding can't
+    # round-trip through config serialization).
+    store2.metadata.embed = CountingEmbedding()
+
+    doc2 = MarkdownDocument(origin="doc2", content="delta epsilon")
+    doc2.chunks = [_get_markdown_chunk(doc2, start=0, end=5)]
+    store2.upsert(doc2)
+
+    assert store2.size() == 2
+
+
 def test_create_does_not_add_chunk_text_column_to_embeddings():
     store = DuckDBStore.create(
         location=":memory:",


### PR DESCRIPTION
## Summary
- `DuckDBStore.connect()` did not load the `vss` extension, so any subsequent write to the `embeddings` table failed with `"Cannot bind index 'embeddings', unknown index type 'HNSW'"` when the database already had HNSW indexes from a previous session.
- Added `_load_extensions_for_existing_indexes()` which inspects `duckdb_indexes()` at connect time and loads the `vss` extension when HNSW indexes are present.
- Added regression test `test_upsert_after_hnsw_index_on_reconnect` that creates a store, builds an HNSW index, closes, reconnects, and upserts a new document.

## Test plan
- [x] New test `test_upsert_after_hnsw_index_on_reconnect` passes
- [x] Full `test_store.py` suite passes (89 tests)