### PR TITLE
Make embedding providers callable via __call__

### DIFF
--- a/src/raghilda/_embedding.py
+++ b/src/raghilda/_embedding.py
@@ -200,6 +200,14 @@ class EmbeddingProvider(ABC):
         """
         NotImplementedError("embed method is not implemented")
 
+    def __call__(
+        self,
+        x: Sequence[str],
+        input_type: EmbedInputType = EmbedInputType.DOCUMENT,
+    ) -> Sequence[Sequence[float]]:
+        """Call `embed` using function-call syntax."""
+        return self.embed(x, input_type=input_type)
+
     @abstractmethod
     def get_config(self) -> dict[str, Any]:
         """

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,6 +1,37 @@
 import pytest
+from typing import Sequence
 from tests import helpers as test_helpers
 from raghilda.embedding import EmbeddingOpenAI
+from raghilda._embedding import EmbeddingProvider, EmbedInputType
+
+
+class DummyEmbeddingProvider(EmbeddingProvider):
+    def __init__(self) -> None:
+        self.last_input_type = EmbedInputType.DOCUMENT
+
+    def embed(
+        self,
+        x: Sequence[str],
+        input_type: EmbedInputType = EmbedInputType.DOCUMENT,
+    ) -> list[list[float]]:
+        self.last_input_type = input_type
+        return [[float(len(text))] for text in x]
+
+    def get_config(self) -> dict:
+        return {"type": "DummyEmbeddingProvider"}
+
+    @classmethod
+    def from_config(cls, config: dict) -> "DummyEmbeddingProvider":
+        return cls()
+
+
+def test_embedding_provider_is_callable() -> None:
+    provider = DummyEmbeddingProvider()
+
+    embeddings = provider(["hello", "a"], input_type=EmbedInputType.QUERY)
+
+    assert embeddings == [[5.0], [1.0]]
+    assert provider.last_input_type == EmbedInputType.QUERY
 
 
 class TestEmbeddingOpenAI:


### PR DESCRIPTION
## Summary
Allow embedding providers to be called like functions while preserving the existing `embed(...)` API.

## Public-facing changes
- Added `EmbeddingProvider.__call__(x, input_type=...)` that forwards to `embed(...)`.
- Users can now write `provider([...])` instead of `provider.embed([...])`.

## Internal-only changes
- Added a regression test to verify callable provider behavior and `input_type` forwarding.
- No changes to embedding model logic or store behavior.

## Testing
- `./.venv/bin/task check`
- `./.venv/bin/task tests`
