### PR TITLE
Exclude docs tooling and env/cache paths from Pyright checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,5 +47,8 @@ lint_check = { cmd = "./.venv/bin/ruff check", help = "ruff lint" }
 lint = { cmd = "./.venv/bin/ruff check --fix", help = "ruff lint --fix" }
 check = { cmd = "./.venv/bin/ruff format --check src tests && ./.venv/bin/ruff check && ./.venv/bin/pyright --pythonpath ./.venv/bin/python && ./.venv/bin/pytest tests src", help = "format+lint+types+tests" }
 
+[tool.pyright]
+exclude = [".venv", ".pytest_cache", ".ruff_cache", "great-docs"]
+
 [tool.uv.sources]
 great-docs = { git = "https://github.com/rich-iannone/great-docs.git" }


### PR DESCRIPTION
## Summary
- Add `[tool.pyright]` excludes for `great-docs`, `.venv`, `.pytest_cache`, and `.ruff_cache`.
- Keep type checks focused on project code.

## Impact
- Public-facing changes: none.
- Internal-only changes: Pyright configuration only.

## Validation
- ./.venv/bin/task check