### PR TITLE
Fix attribute filter token type narrowing

### DIFF
--- a/src/raghilda/_attribute_filters.py
+++ b/src/raghilda/_attribute_filters.py
@@ -375,20 +375,19 @@ def _tokenize_filter(text: str) -> list[_Token]:
             if j >= n or text[j] != "'":
                 raise ValueError("Unterminated string literal in attributes filter")
             raw = text[i : j + 1]
-            value = raw[1:-1].replace("''", "'")
-            tokens.append(_Token(kind="STRING", raw=raw, value=value))
+            string_value = raw[1:-1].replace("''", "'")
+            tokens.append(_Token(kind="STRING", raw=raw, value=string_value))
             i = j + 1
             continue
 
         number_match = _NUMBER_RE.match(text, i)
         if number_match is not None:
             raw = number_match.group(0)
-            value: int | float
             if "." in raw:
-                value = float(raw)
+                number_value: int | float = float(raw)
             else:
-                value = int(raw)
-            tokens.append(_Token(kind="NUMBER", raw=raw, value=value))
+                number_value = int(raw)
+            tokens.append(_Token(kind="NUMBER", raw=raw, value=number_value))
             i = number_match.end()
             continue
 


### PR DESCRIPTION
## Summary

Fix a pyright error in the attribute filter tokenizer by using separate local variables for parsed string and number token values.

This avoids pyright carrying the `int | float` annotation from number parsing over to string parsing in the same function.

## Testing

- `./.venv/bin/ruff format --check src tests`
- `./.venv/bin/ruff check`
- `./.venv/bin/pyright src/raghilda/_attribute_filters.py --pythonpath ./.venv/bin/python`
- `./.venv/bin/pytest tests/test_store.py -k "attribute"`
