### PR TITLE
enh: unify `CrawlScope` pattern API on glob syntax

### DIFF
--- a/src/raghilda/crawl.py
+++ b/src/raghilda/crawl.py
@@ -83,6 +83,8 @@ _DEFAULT_CRAWL_DEPTH = 100_000
 
 RootInput = str | Path
 RootsInput = RootInput | Sequence[RootInput]
+PatternInput = str | re.Pattern[str]
+PatternsInput = PatternInput | Sequence[PatternInput] | None
 CacheValue = tuple[Path | None, dict[str, Any] | None]
 CacheEntry = tuple[str, Path | None, dict[str, Any] | None]
 WebOriginKey = tuple[str, str, int | None]
@@ -93,8 +95,8 @@ TOutput = TypeVar("TOutput")
 @dataclass(frozen=True)
 class CrawlScope:
     roots: RootsInput
-    include_patterns: Sequence[str] | None = None
-    exclude_patterns: Sequence[str] | None = None
+    include_patterns: PatternsInput = None
+    exclude_patterns: PatternsInput = None
     depth: int | None = None
     limit: int | None = None
     include_types: Sequence[str] | None = None
@@ -137,8 +139,10 @@ class _CloudflareRecordCacheEntry:
 @dataclass(frozen=True)
 class _ResolvedCrawlScope:
     roots: list[RootInput]
-    include_patterns: list[str]
-    exclude_patterns: list[str]
+    include_patterns: list[PatternInput]
+    exclude_patterns: list[PatternInput]
+    include_matchers: list[Callable[[str], bool]]
+    exclude_matchers: list[Callable[[str], bool]]
     depth: int
     limit: int | None
     include_types: set[str]
@@ -781,8 +785,8 @@ class DirectoryCrawler(BaseCrawler):
                 if self._include_path(
                     path,
                     origin,
-                    include_patterns=resolved_scope.include_patterns,
-                    exclude_patterns=resolved_scope.exclude_patterns,
+                    include_matchers=resolved_scope.include_matchers,
+                    exclude_matchers=resolved_scope.exclude_matchers,
                     include_types=resolved_scope.include_types,
                     exclude_types=resolved_scope.exclude_types,
                 ):
@@ -810,8 +814,8 @@ class DirectoryCrawler(BaseCrawler):
                 if not self._include_path(
                     file_path,
                     origin,
-                    include_patterns=resolved_scope.include_patterns,
-                    exclude_patterns=resolved_scope.exclude_patterns,
+                    include_matchers=resolved_scope.include_matchers,
+                    exclude_matchers=resolved_scope.exclude_matchers,
                     include_types=resolved_scope.include_types,
                     exclude_types=resolved_scope.exclude_types,
                 ):
@@ -917,15 +921,15 @@ class DirectoryCrawler(BaseCrawler):
         path: Path,
         origin: str,
         *,
-        include_patterns: Sequence[str],
-        exclude_patterns: Sequence[str],
+        include_matchers: Sequence[Callable[[str], bool]],
+        exclude_matchers: Sequence[Callable[[str], bool]],
         include_types: set[str],
         exclude_types: set[str],
     ) -> bool:
         if not _matches_patterns(
             origin,
-            include_patterns=include_patterns,
-            exclude_patterns=exclude_patterns,
+            include_matchers=include_matchers,
+            exclude_matchers=exclude_matchers,
         ):
             return False
         if not include_types and not exclude_types:
@@ -1004,10 +1008,7 @@ class WebCrawler(BaseCrawler):
                     include_subdomains=resolved_scope.include_subdomains,
                 ):
                     continue
-                if _matches_exclude_patterns(
-                    origin,
-                    exclude_patterns=resolved_scope.exclude_patterns,
-                ):
+                if any(matcher(origin) for matcher in resolved_scope.exclude_matchers):
                     continue
                 visited.add(visit_key)
                 batch.append((origin, scope_origin, root_host))
@@ -1041,8 +1042,8 @@ class WebCrawler(BaseCrawler):
                     type_label = (source.metadata or {}).get("type_label")
                     matches_patterns = _matches_patterns(
                         origin,
-                        include_patterns=resolved_scope.include_patterns,
-                        exclude_patterns=resolved_scope.exclude_patterns,
+                        include_matchers=resolved_scope.include_matchers,
+                        exclude_matchers=resolved_scope.exclude_matchers,
                     )
                     matches_types = _matches_types(
                         type_label,
@@ -1481,8 +1482,8 @@ class CloudflareCrawler(BaseCrawler):
         *,
         cache_force_refresh: bool,
         depth: int | None = None,
-        include_patterns: Sequence[str] | None = None,
-        exclude_patterns: Sequence[str] | None = None,
+        include_patterns: Sequence[PatternInput] | None = None,
+        exclude_patterns: Sequence[PatternInput] | None = None,
         include_external_links: bool,
         include_subdomains: bool,
         limit: int | None = None,
@@ -1497,8 +1498,8 @@ class CloudflareCrawler(BaseCrawler):
             resolved_depth,
             resolved_limit,
             apply_patterns,
-            tuple(resolved_include_patterns),
-            tuple(resolved_exclude_patterns),
+            tuple(_pattern_cache_token(p) for p in resolved_include_patterns),
+            tuple(_pattern_cache_token(p) for p in resolved_exclude_patterns),
             include_external_links,
             include_subdomains,
         )
@@ -1616,13 +1617,15 @@ class CloudflareCrawler(BaseCrawler):
                 record["url"] = canonical_url
             completed_records.append(record)
         if apply_patterns:
+            include_matchers = _compile_pattern_matchers(resolved_include_patterns)
+            exclude_matchers = _compile_pattern_matchers(resolved_exclude_patterns)
             completed_records = [
                 record
                 for record in completed_records
-                if _matches_cloudflare_patterns(
+                if _matches_patterns(
                     record["url"],
-                    include_patterns=resolved_include_patterns,
-                    exclude_patterns=resolved_exclude_patterns,
+                    include_matchers=include_matchers,
+                    exclude_matchers=exclude_matchers,
                 )
             ]
         fetched_at = _utcnow()
@@ -1654,8 +1657,8 @@ class CloudflareCrawler(BaseCrawler):
         *,
         depth: int,
         limit: int | None,
-        include_patterns: Sequence[str],
-        exclude_patterns: Sequence[str],
+        include_patterns: Sequence[PatternInput],
+        exclude_patterns: Sequence[PatternInput],
         include_external_links: bool,
         include_subdomains: bool,
         cache_force_refresh: bool,
@@ -1674,10 +1677,21 @@ class CloudflareCrawler(BaseCrawler):
         }
         if limit is not None:
             payload["limit"] = limit
-        if apply_patterns and include_patterns:
-            payload["options"]["includePatterns"] = list(include_patterns)
-        if apply_patterns and exclude_patterns:
-            payload["options"]["excludePatterns"] = list(exclude_patterns)
+        if apply_patterns:
+            # Only glob (str) patterns can be forwarded to the Cloudflare API;
+            # pre-compiled regexes are enforced client-side instead.
+            include_globs = [p for p in include_patterns if isinstance(p, str)]
+            exclude_globs = [p for p in exclude_patterns if isinstance(p, str)]
+            include_has_regex = any(isinstance(p, re.Pattern) for p in include_patterns)
+            # Excludes only ever remove pages, so forwarding the glob subset is
+            # always safe. Includes restrict the result set, so forwarding a
+            # glob subset alongside a regex include would wrongly drop the
+            # regex matches; omit includePatterns entirely in that case and let
+            # the client-side filter do the restriction.
+            if include_globs and not include_has_regex:
+                payload["options"]["includePatterns"] = include_globs
+            if exclude_globs:
+                payload["options"]["excludePatterns"] = exclude_globs
         if self.modified_since is not None:
             payload["modifiedSince"] = self.modified_since
         if cache_force_refresh:
@@ -1802,10 +1816,14 @@ def _coerce_roots(roots: RootsInput) -> list[RootInput]:
 
 
 def _resolve_crawl_scope(scope: CrawlScope) -> _ResolvedCrawlScope:
+    include_patterns = _coerce_pattern_sequence(scope.include_patterns)
+    exclude_patterns = _coerce_pattern_sequence(scope.exclude_patterns)
     return _ResolvedCrawlScope(
         roots=_coerce_roots(scope.roots),
-        include_patterns=_coerce_string_sequence(scope.include_patterns),
-        exclude_patterns=_coerce_string_sequence(scope.exclude_patterns),
+        include_patterns=include_patterns,
+        exclude_patterns=exclude_patterns,
+        include_matchers=_compile_pattern_matchers(include_patterns),
+        exclude_matchers=_compile_pattern_matchers(exclude_patterns),
         depth=_DEFAULT_CRAWL_DEPTH if scope.depth is None else scope.depth,
         limit=scope.limit,
         include_types=_normalize_types(scope.include_types),
@@ -1815,10 +1833,10 @@ def _resolve_crawl_scope(scope: CrawlScope) -> _ResolvedCrawlScope:
     )
 
 
-def _coerce_string_sequence(values: Sequence[str] | str | None) -> list[str]:
+def _coerce_pattern_sequence(values: PatternsInput) -> list[PatternInput]:
     if values is None:
         return []
-    if isinstance(values, str):
+    if isinstance(values, (str, re.Pattern)):
         return [values]
     return list(values)
 
@@ -2013,49 +2031,59 @@ def _normalize_types(types: Sequence[str] | None) -> set[str]:
     return {item.strip().lower() for item in types}
 
 
-def _matches_patterns(
-    origin: str,
-    *,
-    include_patterns: Sequence[str],
-    exclude_patterns: Sequence[str],
-) -> bool:
-    if _matches_exclude_patterns(origin, exclude_patterns=exclude_patterns):
-        return False
-    if not include_patterns:
-        return True
-    return any(re.search(pattern, origin) for pattern in include_patterns)
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a Cloudflare-style glob into a compiled regex.
 
-
-def _matches_exclude_patterns(
-    origin: str,
-    *,
-    exclude_patterns: Sequence[str],
-) -> bool:
-    return any(re.search(pattern, origin) for pattern in exclude_patterns)
-
-
-def _matches_cloudflare_patterns(
-    origin: str,
-    *,
-    include_patterns: Sequence[str],
-    exclude_patterns: Sequence[str],
-) -> bool:
-    for pattern in exclude_patterns:
-        if _wildcard_matches(origin, pattern):
-            return False
-    if not include_patterns:
-        return True
-    return any(_wildcard_matches(origin, pattern) for pattern in include_patterns)
-
-
-def _wildcard_matches(origin: str, pattern: str) -> bool:
+    ``*`` matches any characters except ``/`` and ``**`` matches any
+    characters including ``/``. A trailing ``/**`` also matches the bare
+    parent (so ``/docs/**`` matches ``/docs`` as well as ``/docs/page``).
+    """
     placeholder = "\0"
     regex = re.escape(pattern)
     regex = regex.replace(r"/\*\*", "(?:/.*)?")
     regex = regex.replace(r"\*\*", placeholder)
     regex = regex.replace(r"\*", "[^/]*")
     regex = regex.replace(placeholder, ".*")
-    return re.fullmatch(regex, origin) is not None
+    return re.compile(regex)
+
+
+def _compile_pattern_matchers(
+    patterns: Sequence[PatternInput],
+) -> list[Callable[[str], bool]]:
+    """Compile mixed glob/regex patterns into URL matcher callables.
+
+    ``str`` patterns are treated as globs and matched with ``fullmatch``.
+    Pre-compiled ``re.Pattern`` objects are treated as regexes and matched
+    with ``search`` (the historical behavior for regex patterns).
+    """
+    matchers: list[Callable[[str], bool]] = []
+    for pattern in patterns:
+        if isinstance(pattern, re.Pattern):
+            matchers.append(lambda url, p=pattern: p.search(url) is not None)
+        else:
+            compiled = _glob_to_regex(pattern)
+            matchers.append(lambda url, c=compiled: c.fullmatch(url) is not None)
+    return matchers
+
+
+def _pattern_cache_token(pattern: PatternInput) -> str:
+    """Return a stable, hashable token identifying a glob or regex pattern."""
+    if isinstance(pattern, re.Pattern):
+        return f"re:{pattern.flags}:{pattern.pattern}"
+    return pattern
+
+
+def _matches_patterns(
+    origin: str,
+    *,
+    include_matchers: Sequence[Callable[[str], bool]],
+    exclude_matchers: Sequence[Callable[[str], bool]],
+) -> bool:
+    if any(matcher(origin) for matcher in exclude_matchers):
+        return False
+    if not include_matchers:
+        return True
+    return any(matcher(origin) for matcher in include_matchers)
 
 
 def _matches_types(

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -2956,7 +2956,7 @@ def test_directory_crawler_coerces_scalar_patterns_and_types(
     crawler = DirectoryCrawler()
     scope = CrawlScope(
         roots=[tmp_path],
-        include_patterns=r".*/docs/.*",
+        include_patterns=re.compile(r".*/docs/.*"),
         include_types="markdown",
         exclude_types="python",
     )
@@ -2975,7 +2975,7 @@ def test_directory_crawler_accepts_crawl_scope_for_roots_and_patterns(
     scope = CrawlScope(
         roots=[tmp_path],
         depth=1,
-        include_patterns=[r".*/docs/.*"],
+        include_patterns=["**/docs/**"],
     )
 
     origins = list(crawler.origins(scope, progress=False))

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -2322,6 +2322,32 @@ def test_cloudflare_crawler_accepts_crawl_scope_for_roots_and_patterns(
     ]
 
 
+def test_cloudflare_crawler_applies_regex_includes_client_side(
+    tmp_path: Path,
+) -> None:
+    session = _ParameterizedCloudflareSession()
+    crawler = CloudflareCrawler(
+        account_id="account-123",
+        api_token="token-123",
+        cache_dir=tmp_path / "cloudflare-regex-cache",
+        session=session,
+        poll_interval=0,
+    )
+    # A pre-compiled regex cannot be sent to the Cloudflare API, so it must be
+    # enforced on the records returned by the crawl.
+    scope = CrawlScope(
+        roots=["https://example.com/docs"],
+        depth=1,
+        include_patterns=[re.compile(r".*/page$")],
+    )
+
+    origins = list(crawler.origins(scope, progress=False))
+
+    assert origins == ["https://example.com/docs/page"]
+    # Regex includes are not forwarded to the API.
+    assert "includePatterns" not in session.post_calls[0][1]["options"]
+
+
 def test_cloudflare_crawler_filters_returned_records_to_web_scope(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1129,7 +1129,7 @@ def test_glob_pattern_include_exclude_interaction() -> None:
 
     # `exclude_patterns` will win over `include_patterns` even though the include
     # pattern also matches these URLs (so that users can exclude specific paths or
-    # file types from an otherwise broad crawl). 
+    # file types from an otherwise broad crawl).
     assert not matches("https://example.com/private/notes")
     assert not matches("https://example.com/docs/report.pdf")
 

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -973,6 +973,95 @@ def test_web_crawler_accepts_crawl_scope_for_roots_and_patterns(
         ]
 
 
+def test_web_crawler_single_star_does_not_cross_path_separator(
+    tmp_path: Path,
+) -> None:
+    with _serve(
+        {
+            "/": {
+                "body": (
+                    '<html><body><a href="/docs/guide">Guide</a>'
+                    '<a href="/docs/guide/intro">Intro</a></body></html>'
+                ),
+                "content_type": "text/html; charset=utf-8",
+                "etag": None,
+            },
+            "/docs/guide": {
+                "body": "<html><body><main>Guide</main></body></html>",
+                "content_type": "text/html; charset=utf-8",
+                "etag": None,
+            },
+            "/docs/guide/intro": {
+                "body": "<html><body><main>Intro</main></body></html>",
+                "content_type": "text/html; charset=utf-8",
+                "etag": None,
+            },
+        }
+    ) as server:
+        root_url = f"http://127.0.0.1:{server.server_port}/"
+        crawler = WebCrawler(cache_dir=tmp_path / "single-star-cache")
+        # `*` matches within a path segment only; `docs/guide/intro` is excluded.
+        scope = CrawlScope(
+            roots=[root_url],
+            depth=2,
+            include_patterns=[f"{root_url}docs/*"],
+        )
+
+        origins = list(crawler.origins(scope, progress=False))
+
+        assert origins == [f"{root_url}docs/guide"]
+
+
+def test_web_crawler_accepts_compiled_regex_pattern(tmp_path: Path) -> None:
+    root = "https://example.com"
+    guide = "https://example.com/guide"
+    admin = "https://example.com/admin"
+    session: Any = _FakeWebSession(
+        {
+            root: {
+                "body": (
+                    f'<html><body><a href="{guide}">Guide</a>'
+                    f'<a href="{admin}">Admin</a></body></html>'
+                ),
+            },
+            guide: {"body": "<html><body><main>Guide</main></body></html>"},
+            admin: {"body": "<html><body><main>Admin</main></body></html>"},
+        }
+    )
+    crawler = WebCrawler(
+        cache_dir=tmp_path / "regex-pattern-cache",
+        session=session,
+    )
+    # A pre-compiled regex is the escape hatch and uses `search` semantics.
+    scope = CrawlScope(
+        roots=[root],
+        depth=1,
+        include_patterns=[re.compile(r"/guide$")],
+    )
+
+    origins = list(crawler.origins(scope, progress=False))
+
+    assert guide in origins
+    assert admin not in origins
+
+
+def test_glob_pattern_matchers_segment_semantics() -> None:
+    single = crawl_module._compile_pattern_matchers(["https://example.com/docs/*"])
+    deep = crawl_module._compile_pattern_matchers(["https://example.com/docs/**"])
+
+    def matches(matchers, url: str) -> bool:
+        return crawl_module._matches_patterns(
+            url, include_matchers=matchers, exclude_matchers=[]
+        )
+
+    # `*` stays within a single path segment.
+    assert matches(single, "https://example.com/docs/page")
+    assert not matches(single, "https://example.com/docs/page/sub")
+    # `**` crosses path separators, and a trailing `/**` also matches the bare parent.
+    assert matches(deep, "https://example.com/docs/page/sub")
+    assert matches(deep, "https://example.com/docs")
+
+
 def test_web_markdown_documents_reuses_refreshed_sources(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1062,6 +1062,78 @@ def test_glob_pattern_matchers_segment_semantics() -> None:
     assert matches(deep, "https://example.com/docs")
 
 
+def _glob_matches(pattern: str, url: str) -> bool:
+    matchers = crawl_module._compile_pattern_matchers([pattern])
+    return crawl_module._matches_patterns(
+        url, include_matchers=matchers, exclude_matchers=[]
+    )
+
+
+@pytest.mark.parametrize(
+    ("pattern", "url", "expected"),
+    [
+        # Query strings: `*` stays within a segment, so it does not cross a `/`
+        # embedded in a query value, while `**` matches across everything.
+        ("https://example.com/api?key=*", "https://example.com/api?key=abc123", True),
+        ("https://example.com/api?key=*", "https://example.com/api?key=a/b", False),
+        (
+            "https://example.com/redirect?url=**",
+            "https://example.com/redirect?url=https://other.com/path",
+            True,
+        ),
+        # Regex metacharacters in the pattern are treated literally: `.` and `+`
+        # match only themselves, not "any character".
+        ("https://example.com/a.b+c/page", "https://example.com/a.b+c/page", True),
+        ("https://example.com/a.b+c/page", "https://example.com/aXbXc/page", False),
+        # Percent-encoded characters pass through untouched.
+        (
+            "https://example.com/path%20name/*",
+            "https://example.com/path%20name/file",
+            True,
+        ),
+        # Wildcards in the middle of the URL
+        (
+            "https://example.com/users/*/profile",
+            "https://example.com/users/alice/profile",
+            True,
+        ),
+        (
+            "https://example.com/users/*/profile",
+            "https://example.com/users/alice/extra/profile",
+            False,
+        ),
+        (
+            "https://example.com/docs/**/api",
+            "https://example.com/docs/v1/rest/api",
+            True,
+        ),
+        ("https://example.com/docs/**/api", "https://example.com/docs/api", True),
+    ],
+)
+def test_glob_pattern_matching_covers_complex_urls(
+    pattern: str, url: str, expected: bool
+) -> None:
+    assert _glob_matches(pattern, url) is expected
+
+
+def test_glob_pattern_include_exclude_interaction() -> None:
+    include = crawl_module._compile_pattern_matchers(["https://example.com/**"])
+    exclude = crawl_module._compile_pattern_matchers(["**/private/**", "**/*.pdf"])
+
+    def matches(url: str) -> bool:
+        return crawl_module._matches_patterns(
+            url, include_matchers=include, exclude_matchers=exclude
+        )
+
+    assert matches("https://example.com/public/page")
+
+    # `exclude_patterns` will win over `include_patterns` even though the include
+    # pattern also matches these URLs (so that users can exclude specific paths or
+    # file types from an otherwise broad crawl). 
+    assert not matches("https://example.com/private/notes")
+    assert not matches("https://example.com/docs/report.pdf")
+
+
 def test_web_markdown_documents_reuses_refreshed_sources(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -108,8 +108,8 @@ def test_directory_crawler_discovers_and_converts_markdown_documents(
     scope = CrawlScope(
         roots=[tmp_path],
         depth=3,
-        include_patterns=[r".*/docs/.*"],
-        exclude_patterns=[r".*/skip\.py$"],
+        include_patterns=["**/docs/**"],
+        exclude_patterns=["**/skip.py"],
         include_types=["markdown", "jupyter-notebook"],
     )
 
@@ -333,8 +333,8 @@ def test_web_crawler_discovers_origins_and_revalidates_cache(tmp_path: Path) -> 
         scope = CrawlScope(
             roots=[root_url],
             depth=1,
-            include_patterns=[rf"^{re.escape(root_origin)}(?:/.*)?$"],
-            exclude_patterns=[r".*/skip$"],
+            include_patterns=[f"{root_origin}/**"],
+            exclude_patterns=["**/skip"],
         )
 
         origins = list(crawler.origins(scope, progress=False))
@@ -786,7 +786,7 @@ def test_web_crawler_discovers_matching_descendants_from_filtered_seed(
         scope = CrawlScope(
             roots=[root_url],
             depth=1,
-            include_patterns=[rf"^{re.escape(root_url)}docs/.*"],
+            include_patterns=[f"{root_url}docs/**"],
         )
 
         origins = list(crawler.origins(scope, progress=False))
@@ -812,7 +812,7 @@ def test_web_crawler_does_not_fetch_excluded_origins(tmp_path: Path) -> None:
     scope = CrawlScope(
         roots=[root],
         depth=1,
-        exclude_patterns=[r"/admin$"],
+        exclude_patterns=["**/admin"],
     )
 
     origins = list(crawler.origins(scope, progress=False))
@@ -961,7 +961,7 @@ def test_web_crawler_accepts_crawl_scope_for_roots_and_patterns(
         scope = CrawlScope(
             roots=[root_url],
             depth=1,
-            include_patterns=[rf"^{re.escape(root_url)}docs/.*"],
+            include_patterns=[f"{root_url}docs/**"],
         )
 
         origins = list(crawler.origins(scope, progress=False))

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1134,6 +1134,128 @@ def test_glob_pattern_include_exclude_interaction() -> None:
     assert not matches("https://example.com/docs/report.pdf")
 
 
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        # The query is kept; only the #fragment is dropped.
+        ("https://example.com/p?a=1#frag", "https://example.com/p?a=1"),
+        (
+            "https://example.com/p?a=1&b=2#section-3",
+            "https://example.com/p?a=1&b=2",
+        ),
+        # A fragment with no query leaves a clean path behind.
+        ("https://example.com/p#frag", "https://example.com/p"),
+        # A query with no fragment is untouched.
+        ("https://example.com/p?a=1", "https://example.com/p?a=1"),
+    ],
+)
+def test_canonicalize_web_url_drops_fragment_but_keeps_query(
+    url: str, expected: str
+) -> None:
+    assert crawl_module._canonicalize_web_url(url) == expected
+
+
+def test_web_crawler_preserves_query_string_during_discovery(
+    tmp_path: Path,
+) -> None:
+    root = "https://example.com"
+    search = "https://example.com/search?q=python&page=2"
+    # Query and fragment together: the query stays, the fragment is dropped.
+    page = "https://example.com/p?a=1"
+    session: Any = _FakeWebSession(
+        {
+            root: {
+                "body": (
+                    '<html><body><a href="/search?q=python&page=2">Search</a>'
+                    '<a href="/p?a=1#frag">Page</a></body></html>'
+                ),
+            },
+            search: {"body": "<html><body><main>Results</main></body></html>"},
+            page: {"body": "<html><body><main>Page</main></body></html>"},
+        }
+    )
+    crawler = WebCrawler(
+        cache_dir=tmp_path / "query-discovery-cache",
+        session=session,
+    )
+
+    origins = list(crawler.origins(CrawlScope(roots=[root], depth=1), progress=False))
+
+    # The discovered link keeps its full query string end-to-end.
+    assert search in origins
+    # `https://example.com/p?a=1#frag` -> `https://example.com/p?a=1`: the query
+    # survives and only the fragment is dropped.
+    assert page in origins
+    assert "https://example.com/p?a=1#frag" not in origins
+    # The query-bearing URLs are the ones actually fetched.
+    fetched = {url for url, _ in session.requests}
+    assert {search, page} <= fetched
+
+
+def test_web_crawler_treats_query_variants_as_distinct_origins(
+    tmp_path: Path,
+) -> None:
+    root = "https://example.com/list"
+    page_one = "https://example.com/list?page=1"
+    page_two = "https://example.com/list?page=2"
+    session: Any = _FakeWebSession(
+        {
+            root: {
+                "body": (
+                    '<html><body><a href="/list?page=1">1</a>'
+                    '<a href="/list?page=2">2</a></body></html>'
+                ),
+            },
+            page_one: {"body": "<html><body><main>Page 1</main></body></html>"},
+            page_two: {"body": "<html><body><main>Page 2</main></body></html>"},
+        }
+    )
+    crawler = WebCrawler(
+        cache_dir=tmp_path / "query-variants-cache",
+        session=session,
+    )
+
+    origins = list(crawler.origins(CrawlScope(roots=[root], depth=1), progress=False))
+
+    # URLs that differ only by query string are crawled as separate origins.
+    assert page_one in origins
+    assert page_two in origins
+    fetched = {url for url, _ in session.requests}
+    assert {page_one, page_two} <= fetched
+
+
+def test_web_crawler_patterns_match_query_string_origins(tmp_path: Path) -> None:
+    root = "https://example.com/list"
+    keep = "https://example.com/list?page=1"
+    drop = "https://example.com/list?debug=1"
+    session: Any = _FakeWebSession(
+        {
+            root: {
+                "body": (
+                    '<html><body><a href="/list?page=1">keep</a>'
+                    '<a href="/list?debug=1">drop</a></body></html>'
+                ),
+            },
+            keep: {"body": "<html><body><main>Page 1</main></body></html>"},
+            drop: {"body": "<html><body><main>Debug</main></body></html>"},
+        }
+    )
+    crawler = WebCrawler(
+        cache_dir=tmp_path / "query-patterns-cache",
+        session=session,
+    )
+    # Glob patterns are matched against the full URL, query string included.
+    scope = CrawlScope(
+        roots=[root],
+        depth=1,
+        include_patterns=["https://example.com/list?page=*"],
+    )
+
+    origins = list(crawler.origins(scope, progress=False))
+
+    assert origins == [keep]
+
+
 def test_web_markdown_documents_reuses_refreshed_sources(
     tmp_path: Path,
 ) -> None:

--- a/user_guide/04-crawling-and-ingestion.qmd
+++ b/user_guide/04-crawling-and-ingestion.qmd
@@ -123,8 +123,8 @@ crawler = DirectoryCrawler(cache_dir=True, max_workers=4)
 scope = CrawlScope(
     roots=["docs"],
     depth=3,
-    include_patterns=[r".*\.(md|qmd|ipynb|pdf)$"],
-    exclude_patterns=[r".*/_site/.*", r".*/\.venv/.*"],
+    include_patterns=["**/*.md", "**/*.qmd", "**/*.ipynb", "**/*.pdf"],
+    exclude_patterns=["**/_site/**", "**/.venv/**"],
 )
 
 chunker = MarkdownChunker()

--- a/user_guide/04-crawling-and-ingestion.qmd
+++ b/user_guide/04-crawling-and-ingestion.qmd
@@ -251,10 +251,13 @@ summary = store.ingest(
 print(summary)
 ```
 
-For Cloudflare crawls, `include_patterns` and `exclude_patterns` use
-Cloudflare-style wildcard patterns, such as `https://example.com/docs/**`.
-`include_external_links` and `include_subdomains` are passed through to the
-Cloudflare crawl request.
+`include_patterns` and `exclude_patterns` use the same glob syntax here as for
+the other crawlers (for example, `https://example.com/docs/**`). Glob patterns
+are forwarded directly to Cloudflare's crawl API, which speaks the same `*`/`**`
+wildcard language. Compiled `re.Pattern` objects are also accepted: since the
+API cannot evaluate regexes, they are applied locally to the records Cloudflare
+returns. `include_external_links` and `include_subdomains` are passed through to
+the Cloudflare crawl request.
 
 ## Refresh a store
 

--- a/user_guide/04-crawling-and-ingestion.qmd
+++ b/user_guide/04-crawling-and-ingestion.qmd
@@ -52,8 +52,8 @@ crawler = WebCrawler(
 scope = CrawlScope(
     roots=["https://quarto.org/docs/guide/"],
     depth=2,
-    include_patterns=[r"^https://quarto\.org/docs/guide/"],
-    exclude_patterns=[r"/reference/"],
+    include_patterns=["https://quarto.org/docs/guide/**"],
+    exclude_patterns=["**/reference/**"],
     include_types=["html"],
 )
 
@@ -76,12 +76,23 @@ print(summary)
 | `roots` | Starting files, directories, or URLs. |
 | `depth` | Number of link or directory levels to follow. `0` means only the roots. |
 | `limit` | Maximum number of origins to yield. |
-| `include_patterns` | Regular expressions that origins must match. |
-| `exclude_patterns` | Regular expressions that remove origins from the crawl. |
+| `include_patterns` | Glob patterns (`*`, `**`) that origins must match. Pass a compiled `re.Pattern` for regex matching. |
+| `exclude_patterns` | Glob patterns that remove origins from the crawl. Also accepts compiled `re.Pattern` objects. |
 | `include_types` | Type labels to include, such as `html`, `markdown`, `pdf`, `python`, or `text`. |
 | `exclude_types` | Type labels to skip. |
 | `include_external_links` | Allow links outside the root origin. Defaults to `False`. |
 | `include_subdomains` | Allow subdomains under the root host. Defaults to `False`. |
+
+`include_patterns` and `exclude_patterns` use the same glob syntax across every
+crawler, so the same `CrawlScope` behaves identically whether you run it through
+`WebCrawler`, `DirectoryCrawler`, or `CloudflareCrawler`. A single `*` matches
+any characters except `/` (one path segment), while `**` matches any characters
+including `/` (any number of segments). Patterns are matched against the full
+origin URL, and `exclude_patterns` always take priority over `include_patterns`.
+For matching that globs cannot express (alternation, anchors, character
+classes), pass a pre-compiled `re.Pattern` instead of a string; compiled regexes
+are matched with `re.search`. You can freely mix glob strings and compiled
+regexes in the same list.
 
 `WebCrawler(cache_dir=True)` stores fetched response bodies under
 `.raghilda/cache/web`. With `cache_stale_after`, fresh cached responses are

--- a/user_guide/52-cloudflare-crawler.qmd
+++ b/user_guide/52-cloudflare-crawler.qmd
@@ -184,9 +184,9 @@ scope = CrawlScope(
 
 With `source="sitemap"` and `depth=0`, Cloudflare reads the sitemap from the root and returns all listed pages without further link-following.
 
-## Filtering with Cloudflare-style patterns
+## Filtering with glob patterns
 
-The `include_patterns=` and `exclude_patterns=` fields on `CrawlScope` behave differently depending on which crawler you use. With `WebCrawler`, they are Python regular expressions matched locally. With `CloudflareCrawler`, they are forwarded directly to the Cloudflare API as Cloudflare wildcard patterns, where `**` matches any number of path segments:
+The `include_patterns=` and `exclude_patterns=` fields on `CrawlScope` use the same glob syntax for every crawler, so a scope you tuned against `WebCrawler` behaves identically with `CloudflareCrawler`. A single `*` matches any characters except `/` (one path segment), and `**` matches any characters including `/` (any number of segments). Patterns are matched against the full URL:
 
 ```{python}
 #| eval: false
@@ -202,7 +202,22 @@ scope = CrawlScope(
 )
 ```
 
-The `include_patterns` list restricts the crawl to URLs matching at least one pattern. The `exclude_patterns` list removes URLs that match any pattern. The `limit=` field caps the total number of pages returned.
+The `include_patterns` list restricts the crawl to URLs matching at least one pattern. The `exclude_patterns` list removes URLs that match any pattern, and always takes priority over `include_patterns`. The `limit=` field caps the total number of pages returned.
+
+Because Cloudflare's crawl API speaks the same `*`/`**` wildcard language, glob patterns are forwarded directly to it so the filtering happens server-side. For matching that globs cannot express, pass a pre-compiled `re.Pattern` (matched with `re.search`) instead of a string:
+
+```{python}
+#| eval: false
+import re
+
+scope = CrawlScope(
+    roots=["https://example.com/"],
+    depth=2,
+    include_patterns=[re.compile(r"/docs/v\d+/")],
+)
+```
+
+Since the Cloudflare API cannot evaluate regexes, compiled patterns are not forwarded; `CloudflareCrawler` applies them locally to the records the crawl returns. You can mix glob strings and compiled regexes in the same list, and the glob portion is still pushed to the API for efficient server-side filtering.
 
 Two additional scope fields are relevant for Cloudflare crawls:
 


### PR DESCRIPTION
This PR unifies how `CrawlScope`'s `include_patterns` and `exclude_patterns` are interpreted. It now provides a single glob syntax (`*` for one path segment, `**` for any number of segments) that works identically across `WebCrawler`, `DirectoryCrawler`, and `CloudflareCrawler`.

Before the web/directory crawlers treated patterns as regexes while Cloudflare used globs. This wasn't ideal as it would force users to rewrite patterns when switching backends. The strategy here is to have globs converted to regexes under the hood for local matching, while Cloudflare still receives them directly (so, standardizing on Cloudflare's patterns).

For matching that globs can't express, you can now pass a pre-compiled `re.Pattern` (matched with `re.search`) anywhere a string is accepted. You can even freely mix the two in one list. For Cloudflare, these regexes are applied client-side to returned records since the API can't evaluate them.

Important to note here that this is a change for existing `WebCrawler`/`DirectoryCrawler` users who passed regex strings. Those now must now be globs or wrapped in `re.compile(...)`.

Fixes: https://github.com/posit-dev/raghilda/issues/79