### PR TITLE
docs: make small fixes to documentation

### DIFF
--- a/great-docs.yml
+++ b/great-docs.yml
@@ -57,6 +57,12 @@ funding:
 repo: https://github.com/posit-dev/raghilda
 github_style: widget  # "widget" shows star count, "icon" shows just the icon
 
+# Site URL
+# --------
+# Canonical address of the deployed documentation site. Used for the Skills page
+# install commands, .well-known/ discovery, and sitemaps.
+site_url: https://posit-dev.github.io/raghilda/
+
 # API Reference Structure
 # -----------------------
 # Customize the sections below to organize your API documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
 
 [project.urls]
 Repository = "https://github.com/posit-dev/raghilda"
-PyPI = "https://pypi.org/project/raghilda/"
 
 [build-system]
 requires = ["uv_build>=0.8.0,<0.9"]

--- a/user_guide/00-getting-started.qmd
+++ b/user_guide/00-getting-started.qmd
@@ -272,4 +272,4 @@ for chunk in chunks:
 - Learn schema-based retrieval scoping with [Attribute Filters](03-attribute-filters.qmd)
 - Explore [ChromaDB Store](50-chromadb-store.qmd) for an alternative storage backend
 - See the [API Reference](/reference/index.qmd) for detailed documentation
-- Check out the [examples](https://github.com/dfalbel/py-ragnar/tree/main/examples) for more use cases
+- Check out the [examples](https://github.com/posit-dev/raghilda/tree/main/examples) for more use cases


### PR DESCRIPTION
This PR fixes three small documentation issues in raghilda: a broken "examples" link in the Getting Started guide that pointed at the project's old `dfalbel/py-ragnar` repo, and a duplicate PyPI link on the landing page caused by a redundant `[project.urls]` entry. It also sets `site_url` in `great-docs.yml`, which populates the canonical documentation address so the auto-generated Skills page renders working install commands instead of showing a literal `<site-url>/skill.md` placeholder in the manual/curl option.