### PR TITLE
docs: add two new user guide pages for onboarding, reorganize user guide, add README.md polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ pip install git+https://github.com/posit-dev/raghilda.git
 
 raghilda handles the complete RAG pipeline:
 
-1. **Document Processing** — Convert documents to Markdown using MarkItDown
-2. **Text Chunking** — Split text at semantic boundaries (headings, paragraphs, sentences)
-3. **Embedding** — Generate vector representations via OpenAI or other providers
-4. **Storage** — Store chunks and embeddings in DuckDB, ChromaDB, or OpenAI Vector Stores
-5. **Retrieval** — Find relevant chunks using similarity search or BM25
+1. document Processing: convert documents to Markdown using MarkItDown
+2. text chunking: split text at semantic boundaries (headings, paragraphs, sentences)
+3. embedding: generate vector representations via OpenAI or other providers
+4. storage: store chunks and embeddings in DuckDB, ChromaDB, or OpenAI Vector Stores
+5. retrieval: find relevant chunks using similarity search or BM25
+
+Each step is an ordinary, inspectable Python object with sensible defaults, so you can run the whole pipeline as-is and customize any stage when you need to.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ for chunk in chunks:
 ## Links
 
 - [Documentation](https://posit-dev.github.io/raghilda/)
-- [Source Code](https://github.com/posit-dev/raghilda)
 - [PyPI](https://pypi.org/project/raghilda/)
-- [Report Issues](https://github.com/posit-dev/raghilda/issues)
+- [Report an issue](https://github.com/posit-dev/raghilda/issues)
+
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING](CONTRIBUTING.md) for setup and development guidelines.
+
+## License
+
+Released under the MIT License.
+
+---
+
+<p align="center">
+Developed by <strong>Daniel&nbsp;Falbel</strong> and <strong>Tomasz&nbsp;Kalinowski</strong>.<br>
+Supported by <a href="https://posit.co"><strong>Posit&nbsp;Software,&nbsp;PBC</strong></a>.
+</p>

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ for chunk in chunks:
     print(chunk.text)
 ```
 
+## Requirements
+
+- **Python 3.11–3.13**
+- An embedding provider (such as OpenAI) is optional: semantic search needs one, but keyword search works with no API key.
+
 ## Links
 
 - [Documentation](https://posit-dev.github.io/raghilda/)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ store = DuckDBStore.create(
 links = find_links("https://posit-dev.github.io/chatlas/")
 chunker = MarkdownChunker()
 
+# Read, chunk, and store each page
 for link in links:
     document = read_as_markdown(link)
     chunked_document = chunker.chunk(document)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 RAG made simple.
 
-raghilda is a Python package for implementing Retrieval-Augmented Generation (RAG) workflows. It provides a complete solution with sensible defaults while remaining transparent—not a black box.
+raghilda is a Python package for implementing Retrieval-Augmented Generation (RAG) workflows. It provides a complete solution with sensible defaults while remaining transparent (not a black box).
+
+## What you can build
+
+raghilda puts a question-answering layer over content you already have. Use it to chat over your documentation with cited sources, build internal knowledge assistants over runbooks, wikis, or policies (scoped per team or product with attribute filters), run research and Q&A across a directory of PDFs, notebooks, or reports, or power entity-scoped retrieval over customer records, product catalogs, and case timelines where every answer must stay within a single record.
 
 ## Installation
 

--- a/user_guide/00-why-raghilda.qmd
+++ b/user_guide/00-why-raghilda.qmd
@@ -1,0 +1,120 @@
+---
+title: "Why raghilda?"
+guide-section: "Get Started"
+---
+
+raghilda is a Python library for building Retrieval-Augmented Generation (RAG)
+systems: pipelines that let a large language model answer questions using *your*
+content instead of relying only on what it learned during training.
+
+If you are deciding whether raghilda is the right tool, this page explains the
+problem it solves, what makes it different from other RAG frameworks, and the
+kinds of applications it is built for. If you would rather just see it run, head
+on over to the [Quickstart](quickstart.qmd).
+
+## The problem
+
+Large language models are fluent but ungrounded. Ask one about your internal
+documentation, a recent release, or a private knowledge base, and it will often
+produce a confident answer that is subtly (or completely) wrong.
+
+RAG addresses this by retrieving relevant passages from a trusted source and placing
+them in the model's prompt, so the model summarizes vetted material instead of
+recalling from memory. Building that retrieval layer well means solving a chain
+of smaller problems:
+
+1. converting source documents to clean text
+2. splitting into well-sized chunks
+3. embedding those chunks
+4. storing them in a database that supports similarity search
+5. querying that database effectively
+
+raghilda handles every step of that process.
+
+## What makes raghilda different
+
+There are several capable RAG frameworks in the Python ecosystem. raghilda's
+design leans on three principles:
+
+**Complete, with sensible defaults.**
+
+The full pipeline (find, read, chunk,
+embed, store, retrieve) is covered completely. You can build a working store fairly
+easily, and the defaults (semantic boundary chunking, hybrid retrieval, automatic
+deduplication) are tuned to produce good results before you tune anything yourself.
+
+**Transparent, not a black box.**
+
+Every stage is an ordinary Python object you can inspect, print, and replace. The
+`read_as_markdown()` function returns a document you can read. With `chunker.chunk()`,
+you get chunks that you can examine. The `store.retrieve()` method returns
+scored results with their source and metrics attached. There is no hidden
+orchestration layer deciding things for you. When retrieval returns something
+surprising, you can see exactly why.
+
+**Built on storage you already trust.**
+
+raghilda can store chunks and embeddings in established databases like
+[DuckDB](https://duckdb.org) (by default), ChromaDB, PostgreSQL (with pgvector),
+or OpenAI Vector Stores. Your knowledge base is a real database file or server you
+can back up, inspect with standard tools, and move between machines. It's not a
+custom format locked inside the framework.
+
+## How it compares
+
+Frameworks like LangChain, LlamaIndex, and Haystack are broad orchestration
+toolkits that cover agents, chains, prompt management, and many integrations in
+addition to retrieval. They are indeed very powerful, but that breadth comes with
+abstraction layers and a larger surface area to learn.
+
+raghilda is deliberately narrower. It focuses on doing the retrieval pipeline
+really well and staying out of your way for everything else (including the
+conversation itself, which you wire up with whatever chat library you prefer). If
+you want a retrieval layer you can fully understand and a knowledge base that lives
+in a normal database, raghilda is a good fit. If you need a large catalog of
+pre-built agent integrations in one package, a broader framework might suit you
+better.
+
+## What you can build
+
+The same core workflow supports a range of applications:
+
+**Chat over your documentation.**
+
+Index a docs site or a folder of Markdown and give users an assistant that answers
+from it, with sources cited. This is the pattern in
+[Using RAG with chatlas](chatlas-integration.qmd).
+
+**Internal knowledge assistants.**
+
+Build a support tool over policy documents or wikis, and scope each query to the
+right subset using [attribute filters](attribute-filters.qmd) (filtering by team or
+by product).
+
+**Research and Q&A over a document collection.**
+
+Use raghilda with a directory of PDFs, notebooks, or reports and ask questions
+across all of them.
+
+**Entity-scoped retrieval.**
+
+Customer records, product catalogs, or case timelines where every answer must stay
+within one record (this can be handled cleanly with attribute schemas and filters).
+
+## When raghilda is a good fit
+
+raghilda is a strong choice when:
+
+- you want a complete RAG pipeline that you can read end to end
+- you value a knowledge base that lives in a familiar database
+- you would rather compose your own chat layer than adopt a full orchestration
+framework
+
+It is less suited to projects that primarily need a large library of off-the-shelf
+agent and tool integrations bundled together.
+
+## Next steps
+
+- try the [Quickstart](quickstart.qmd): a runnable example with no API key.
+- read [Core Concepts](getting-started.qmd) to build a real store with embeddings.
+- browse the [API Reference](/reference/index.qmd) for the full surface.

--- a/user_guide/00-why-raghilda.qmd
+++ b/user_guide/00-why-raghilda.qmd
@@ -71,9 +71,7 @@ raghilda is deliberately narrower. It focuses on doing the retrieval pipeline
 really well and staying out of your way for everything else (including the
 conversation itself, which you wire up with whatever chat library you prefer). If
 you want a retrieval layer you can fully understand and a knowledge base that lives
-in a normal database, raghilda is a good fit. If you need a large catalog of
-pre-built agent integrations in one package, a broader framework might suit you
-better.
+in a normal database, raghilda is a good fit.
 
 ## What you can build
 

--- a/user_guide/01-quickstart.qmd
+++ b/user_guide/01-quickstart.qmd
@@ -1,0 +1,162 @@
+---
+title: "Quickstart"
+guide-section: "Get Started"
+---
+
+This page builds a tiny, working RAG store and searches it. No API key is
+required and no network access is needed either. It runs fairly quickly and is
+probably the fastest way for confirming whether raghilda does what you expect it
+to do (before setting up an embedding provider).
+
+The neat thing here is that raghilda's `DuckDBStore` can run fully in memory
+(with the `embed=None` option) and it can search with BM25 keyword retrieval,
+which needs no embedding model. Once you have a good working understanding of the
+workflow here, the [Core Concepts](getting-started.qmd) page will show you how to
+add embeddings for semantic search.
+
+## Installation
+
+raghilda is a single package on PyPI. The base install includes everything this
+quickstart needs (the [DuckDB](https://duckdb.org) storage backend and the BM25
+keyword search engine) so there are no separate services or databases to set up:
+
+```bash
+pip install raghilda
+```
+
+Other storage backends and embedding providers are available as optional extras
+(for example, `pip install "raghilda[chromadb]"`), but you won't need any of them
+in this guide page.
+
+## Build a store and search it
+
+We'll create a miniature knowledge base (three one-paragraph documents about
+planets) and then ask it a question. Everything runs in memory, so nothing is
+written to disk and no network service is contacted. Read through the code first
+to get a feel for the order of execution. Each piece of this code example will
+be explained below it.
+
+```{python}
+from raghilda.store import DuckDBStore
+from raghilda.document import MarkdownDocument
+from raghilda.chunker import MarkdownChunker
+
+# Create an in-memory store with no embedding provider (keyword search only)
+store = DuckDBStore.create(location=":memory:", embed=None)
+
+# Create a chunker with default settings
+chunker = MarkdownChunker()
+
+# Define three short source documents (normally you'd load these from files or URLs)
+documents = [
+    MarkdownDocument(
+        origin="mars.md",
+        content="Mars is the fourth planet from the Sun. It is known as the "
+        "red planet because of iron oxide on its surface, and it has the "
+        "tallest volcano in the solar system, Olympus Mons.",
+    ),
+    MarkdownDocument(
+        origin="saturn.md",
+        content="Saturn is the sixth planet from the Sun and is famous for its "
+        "spectacular ring system, the largest and brightest of any planet, made "
+        "mostly of ice and rock.",
+    ),
+    MarkdownDocument(
+        origin="jupiter.md",
+        content="Jupiter is the largest planet in the solar system. It is a gas "
+        "giant with a Great Red Spot, a giant storm that has raged for centuries.",
+    ),
+]
+
+# Chunk each document and write the resulting chunks into the store
+for doc in documents:
+    store.upsert(chunker.chunk(doc))
+
+# Build the BM25 keyword index over the stored chunks
+store.build_index("bm25")
+
+# Search for the chunks most relevant to the query (at most two)
+results = store.retrieve("Which planet has the largest rings?", top_k=2, deoverlap=False)
+
+# Print each result with its source label
+for chunk in results:
+    print(f"{chunk.origin}: {chunk.text}")
+```
+
+The query never mentions "Saturn" yet the Saturn passage comes back first. That
+is not magic and the rest of this page explains exactly why.
+
+## The pieces
+
+Each object in the example maps to one step of the RAG workflow:
+
+`MarkdownDocument` represents a unit of source content plus a label for where it came
+from (its `origin`). Here we typed the text inline, but normally you would load
+documents from files or URLs with `read_as_markdown()`. The `origin` travels with
+the content all the way to your search results, so you always know where a passage
+came from.
+
+Let's now look at `MarkdownChunker` and `chunker.chunk(doc)`. A chunker splits a
+document into smaller passages called *chunks*. Our planet blurbs are short, so each
+becomes a single chunk. Now a real page would be split into several, and that's so a
+search can return one focused passage instead of a whole document. The
+[Chunking](chunking.qmd) guide covers how the splitting decisions are made.
+
+The `store.upsert(...)` statement writes chunks into the store. An *Upsert* is
+short for *update-or-insert*, so re-running it with the same document updates the
+existing entry instead of creating a duplicate (this makes re-indexing safe to
+repeat).
+
+Using `store.build_index("bm25")` builds the search index over everything stored.
+You build it once after loading your documents. Queries afterward are fast.
+
+The use of `store.retrieve("Which planet has the largest rings?", top_k=2, deoverlap=False)`
+runs the search. The `top_k=2` option asks for at most two results, and
+`deoverlap=False` keeps chunks separate (merging overlapping chunks only matters
+once documents are long enough to span several chunks). It returns a list of
+`RetrievedChunk` objects (ordered best match first), each carrying its `text`,
+its `origin`, and relevance `metrics` you can inspect.
+
+## How the search actually works
+
+The search here is BM25, a long-established keyword ranking algorithm from the
+same family that powers traditional search engines. Here's what it is essentially
+doing:
+
+- It compares the **words** in your query against the words in each stored chunk.
+- A chunk scores higher when it shares more of the query's words and when those
+shared words are **rare** across the collection (rare words are more distinctive
+than common ones). The score is also adjusted so a chunk is not rewarded simply
+for being long.
+- The chunks are returned in score order, highest first.
+
+That is why `"Which planet has the largest rings?"` returns the Saturn passage
+first: the query's meaningful words ("planet", "largest", and "ring") all appear
+in it. No understanding of astronomy (or even of your question) is involved. BM25
+is just matching and counting words.
+
+::: {.callout-note}
+## For the observant reader
+
+You may have spotted that the query asks about "rings" (plural) while the Saturn
+text says "ring system" (singular). The match still works because BM25 does not
+compare raw words. Before indexing (and again when you search) it normalizes the
+text: it lowercases everything, drops common *stop words* (such as *which*, *has*,
+and *the*), and **stems** each remaining word down to a root form. DuckDB's
+full-text search uses the Porter stemmer by default, which reduces both *ring* and
+*rings* to the stem *ring*, so the singular and the plural are treated as the same
+term.
+:::
+
+Knowing that also makes BM25's main limitation clear. If you were to ask instead
+`"Which planet has the most prominent halo?"`, the word halo never appears in any
+document, so the Saturn passage ranks no higher than the others (even though halo and
+rings mean nearly the same thing here). Bridging that gap, matching on meaning rather
+than exact words, is what embeddings and semantic search add, and it is the subject
+of [Core Concepts](getting-started.qmd).
+
+## Next steps
+
+- [Core Concepts](getting-started.qmd): add an embedding provider for semantic
+(meaning-based) search and hybrid retrieval, and index a real documentation site.
+- [Chunking](chunking.qmd): tune chunk size and overlap for retrieval quality.

--- a/user_guide/02-getting-started.qmd
+++ b/user_guide/02-getting-started.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Core Concepts"
-guide-section: "Getting Started"
+guide-section: "Get Started"
 ---
 
 Large language models (LLMs) sometimes generate confident but incorrect information—a phenomenon known as hallucination. This happens because LLMs work by predicting the most likely next words based on patterns learned during training, without any inherent concept of truth or factual accuracy.
@@ -19,6 +19,20 @@ A RAG system has two main phases:
 2. **Retrieval**: Finding relevant content to augment LLM prompts
 
 Let's walk through building a RAG system using the [Quarto documentation](https://quarto.org/docs/guide/) as our knowledge base.
+
+::: {.callout-note}
+## Before you start
+
+The examples on this page use OpenAI embeddings, which read your API key from the
+`OPENAI_API_KEY` environment variable:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+Want to try raghilda without an API key first? The [Quickstart](quickstart.qmd)
+builds a working store using keyword search and no external services.
+:::
 
 ## Creating a Store
 
@@ -142,7 +156,7 @@ Common reasons to customize `prepare`:
 - **Adjust chunk size or overlap** — Smaller chunks for more precise retrieval, larger for more context.
 - **Set hard heading boundaries** — Use `segment_by_heading_levels=[1, 2]` to prevent chunks from crossing major sections.
 - **Control HTML extraction** — Pass `html_extract_selectors` or `html_zap_selectors` to `read_as_markdown()`.
-- **Use a different chunker** — Any chunker that returns a chunked document will work. See the [Chunking](02-chunking.qmd) guide for more options, including [chonkie](https://github.com/chonkie-ai/chonkie) integration.
+- **Use a different chunker** — Any chunker that returns a chunked document will work. See the [Chunking](chunking.qmd) guide for more options, including [chonkie](https://github.com/chonkie-ai/chonkie) integration.
 
 ## Building Indexes
 
@@ -268,8 +282,8 @@ for chunk in chunks:
 
 ## Next Steps
 
-- Learn about chunk sizing, overlap, and alternative chunkers in the [Chunking](02-chunking.qmd) guide
-- Learn schema-based retrieval scoping with [Attribute Filters](03-attribute-filters.qmd)
-- Explore [ChromaDB Store](50-chromadb-store.qmd) for an alternative storage backend
+- Learn about chunk sizing, overlap, and alternative chunkers in the [Chunking](chunking.qmd) guide
+- Learn schema-based retrieval scoping with [Attribute Filters](attribute-filters.qmd)
+- Explore [ChromaDB Store](chromadb-store.qmd) for an alternative storage backend
 - See the [API Reference](/reference/index.qmd) for detailed documentation
-- Check out the [examples](https://github.com/dfalbel/py-ragnar/tree/main/examples) for more use cases
+- Check out the [examples](https://github.com/posit-dev/raghilda/tree/main/examples) for more use cases

--- a/user_guide/10-chunking.qmd
+++ b/user_guide/10-chunking.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Chunking"
-guide-section: "Getting Started"
+guide-section: "Building a Store"
 ---
 
 Chunking is the process of splitting documents into smaller pieces for embedding and retrieval. Good chunking improves retrieval quality by ensuring each chunk contains a coherent, self-contained piece of information.

--- a/user_guide/11-custom-embedding-providers.qmd
+++ b/user_guide/11-custom-embedding-providers.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Custom Embedding Providers"
-guide-section: "Getting Started"
+guide-section: "Building a Store"
 ---
 
 raghilda includes built-in support for OpenAI and Cohere embeddings, but you can create custom providers for other embedding services or local models.
@@ -140,6 +140,20 @@ query_embedding = provider.embed([query], input_type=EmbedInputType.QUERY)
 Some models (like Cohere and Voyage) produce different embeddings for queries vs documents to optimize retrieval. Others (like OpenAI) ignore this parameter. Your provider should handle both cases appropriately.
 
 ## Local Models Example
+
+::: {.callout-tip}
+raghilda already ships a built-in `EmbeddingSentenceTransformers` provider. For
+real use you don't need to write your own — just install the extra
+(`pip install "raghilda[sentence-transformers]"`) and import it:
+
+```python
+from raghilda.embedding import EmbeddingSentenceTransformers
+```
+
+The example below is illustrative: it shows how an equivalent local provider is
+written from scratch, which is a useful template when you need to wrap a local
+model that raghilda does not support out of the box.
+:::
 
 Here's an example using a local model with sentence-transformers:
 

--- a/user_guide/12-crawling-and-ingestion.qmd
+++ b/user_guide/12-crawling-and-ingestion.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Crawling and Ingestion"
-guide-section: "Getting Started"
+guide-section: "Building a Store"
 ---
 
 raghilda's core workflow is intentionally sequential: find a source, read it,

--- a/user_guide/13-cloudflare-crawler.qmd
+++ b/user_guide/13-cloudflare-crawler.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Cloudflare Browser Rendering Crawler"
-guide-section: "Store Backends"
+guide-section: "Building a Store"
 ---
 
 The `CloudflareCrawler` delegates all page fetching and rendering to [Cloudflare's Browser Rendering API](https://developers.cloudflare.com/browser-rendering/). This provides a lot of benefits if you have an account with Cloudflare:
@@ -9,7 +9,7 @@ The `CloudflareCrawler` delegates all page fetching and rendering to [Cloudflare
 - those websites that load their content entirely through JavaScript (which make text retrieval generally problematic) are handled by Cloudflare
 - you don't have to run a headless browser locally, you simply receive ready-to-chunk text from the paid service
 
-This guide covers how to set up and use `CloudflareCrawler` to build a store. It assumes some familiarity with the general crawling workflow described in [Crawling and Ingestion](04-crawling-and-ingestion.qmd).
+This guide covers how to set up and use `CloudflareCrawler` to build a store. It assumes some familiarity with the general crawling workflow described in [Crawling and Ingestion](crawling-and-ingestion.qmd).
 
 ## Prerequisites
 

--- a/user_guide/20-attribute-filters.qmd
+++ b/user_guide/20-attribute-filters.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Attribute Filters"
-guide-section: "Getting Started"
+guide-section: "Using Your Store"
 ---
 
 RAG depends on retrieving relevant context, but real stores are usually broad

--- a/user_guide/21-chatlas-integration.qmd
+++ b/user_guide/21-chatlas-integration.qmd
@@ -1,11 +1,11 @@
 ---
 title: "Using RAG with chatlas"
-guide-section: "Getting Started"
+guide-section: "Using Your Store"
 ---
 
 While raghilda builds the knowledge store, [chatlas](https://posit-dev.github.io/chatlas/) can handle the conversation part. The integration point between the two is a Python function that you register as a tool with chatlas. When the LLM decides it needs information from your store, it calls that function, receives the relevant chunks, and incorporates them into its answer.
 
-This page will walk you through the pattern step by step. It assumes you already have a populated store (look over [Core Concepts](00-getting-started.qmd) or [Crawling and Ingestion](04-crawling-and-ingestion.qmd) if you need to build one first).
+This page will walk you through the pattern step by step. It assumes you already have a populated store (look over [Core Concepts](getting-started.qmd) or [Crawling and Ingestion](crawling-and-ingestion.qmd) if you need to build one first).
 
 ## Connecting to a store
 
@@ -147,7 +147,7 @@ def search_guides(query: str) -> str:
     return json.dumps([{"text": chunk.text} for chunk in chunks])
 ```
 
-Here only chunks whose `section` attribute equals `'guide'` are considered. This keeps retrieval focused and avoids pulling in, for example, API reference text when the user asks a conceptual question. See [Attribute Filters](03-attribute-filters.qmd) for more on defining and using attribute schemas.
+Here only chunks whose `section` attribute equals `'guide'` are considered. This keeps retrieval focused and avoids pulling in, for example, API reference text when the user asks a conceptual question. See [Attribute Filters](attribute-filters.qmd) for more on defining and using attribute schemas.
 
 You can also register several tool functions on the same chat, each backed by a different filter or even a different store. The model decides which tool to invoke based on the docstrings, so give each function a clear description of what it covers:
 
@@ -307,7 +307,7 @@ This script separates store construction from chat setup so the expensive indexi
 
 ## Next steps
 
-- The [Core Concepts](00-getting-started.qmd) guide covers building a store from scratch.
-- The [Chunking](02-chunking.qmd) guide explains how to tune chunk size and overlap for better retrieval quality.
-- The [Attribute Filters](03-attribute-filters.qmd) guide shows how to scope retrieval by metadata.
+- The [Core Concepts](getting-started.qmd) guide covers building a store from scratch.
+- The [Chunking](chunking.qmd) guide explains how to tune chunk size and overlap for better retrieval quality.
+- The [Attribute Filters](attribute-filters.qmd) guide shows how to scope retrieval by metadata.
 - The [chatlas documentation](https://posit-dev.github.io/chatlas/get-started/tools.html) has more detail on tool calling, streaming, and structured output.

--- a/user_guide/30-chromadb-store.qmd
+++ b/user_guide/30-chromadb-store.qmd
@@ -1,6 +1,6 @@
 ---
-title: "Getting Started"
-guide-section: "ChromaDB Store"
+title: "ChromaDB Store"
+guide-section: "Storage Backends"
 ---
 
 ChromaDB is an open-source vector database designed for AI applications. raghilda's
@@ -174,7 +174,7 @@ print(f"Documents in store: {store.size()}")
 ::: {.callout-note}
 When using ChromaDB's built-in embedding functions or raghilda's `EmbeddingOpenAI`/`EmbeddingCohere`,
 the embedding function is automatically restored from the stored configuration.
-See [Embedding Functions](51-chromadb-embedding-functions.qmd) for details.
+See [Embedding Functions](chromadb-embedding-functions.qmd) for details.
 :::
 
 ## Using a Remote ChromaDB Server
@@ -237,5 +237,5 @@ for i, chunk in enumerate(results, 1):
 
 ## Next Steps
 
-- Learn about [Embedding Functions](51-chromadb-embedding-functions.qmd) for advanced embedding configuration
+- Learn about [Embedding Functions](chromadb-embedding-functions.qmd) for advanced embedding configuration
 - Explore the [API Reference](/reference/store.ChromaDBStore.qmd) for all available methods

--- a/user_guide/31-chromadb-embedding-functions.qmd
+++ b/user_guide/31-chromadb-embedding-functions.qmd
@@ -1,6 +1,6 @@
 ---
-title: "Embedding Functions"
-guide-section: "ChromaDB Store"
+title: "ChromaDB Embedding Functions"
+guide-section: "Storage Backends"
 ---
 
 Embedding functions convert text into numerical vectors that capture semantic meaning.


### PR DESCRIPTION
This PR restructures the User Guide into four progressive sections (Get Started, Building a Store, Using Your Store, and Storage Backends) by renumbering the source files (no changes to any published URLs). Adds two new Get Started pages:

1. a "Why raghilda?" positioning page
2. a runnable, no-API-key Quickstart

The PR also polishes the README and provides a fuller footer (Requirements, Links, Contributing, License, etc.).