### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 0.2
+
+raghilda 0.2 expands the package from the core RAG workflow into a more
+complete toolkit for building and maintaining retrieval stores. The release
+adds crawl and ingest APIs with caching and concurrency, a Cloudflare-backed
+crawler for JavaScript-rendered sites, a PostgreSQL store backend, and NVIDIA
+NIM embedding support.
+
 ### Added
 
 - Added `raghilda.crawl`, including `CrawlScope`, `FetchedSource`,
@@ -11,7 +19,28 @@
 - Added `BaseStore.ingest()` and `IngestSummary` for bulk document ingestion
   with optional document preparation, parallel writes, and inserted, replaced,
   and skipped counts.
+- Added crawler caching so repeated or interrupted crawls can reuse fetched and
+  converted content.
+- Added `CloudflareCrawler` for crawling and converting JavaScript-rendered
+  sites through Cloudflare's Browser Rendering API.
+- Added `PostgreSQLStore`, backed by `psycopg2` and `pgvector`, with full-text
+  search, vector search, combined retrieval, attributes, and HNSW index support.
+- Added `EmbeddingNVIDIA` for NVIDIA NIM embeddings, including differentiated
+  query and document input types and rate-limit backoff.
+- Added user guide pages for quickstart, crawling and ingestion, Cloudflare
+  crawling, and chatlas integration.
+
+### Changed
+
+- `CrawlScope.include_patterns` and `CrawlScope.exclude_patterns` now use one
+  glob-style pattern syntax across `DirectoryCrawler`, `WebCrawler`, and
+  `CloudflareCrawler`.
+- Existing regex strings passed to `WebCrawler` or `DirectoryCrawler` should be
+  rewritten as globs or passed as compiled `re.Pattern` objects.
+- Reorganized the user guide onboarding pages and refreshed the README.
 
 ### Fixed
 
 - Fixed sitemap URL extraction so each `<loc>` entry is collected as one URL.
+- Improved DuckDB BM25 retrieval errors when the index has not been built or
+  has become stale.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## 0.2
+## 0.2.0
 
-raghilda 0.2 expands the package from the core RAG workflow into a more
+raghilda 0.2.0 expands the package from the core RAG workflow into a more
 complete toolkit for building and maintaining retrieval stores. The release
 adds crawl and ingest APIs with caching and concurrency, a Cloudflare-backed
 crawler for JavaScript-rendered sites, a PostgreSQL store backend, and NVIDIA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raghilda"
-version = "0.1.1"
+version = "0.2"
 description = "RAG made simple"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ postgres = ["psycopg2-binary"]
 dev = [
     "dotenv>=0.9.9",
     "great-docs",
-    "griffe>=1.5.0,<2.0",
     "taskipy>=1.14.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raghilda"
-version = "0.2"
+version = "0.2.0"
 description = "RAG made simple"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bumps the package version to `0.2.0`.
- Adds the `0.2.0` changelog section with the approved release notes.
- Removes the stale direct `griffe<2.0` dev dependency so CI can resolve the current `great-docs` git dependency.

## Public Facing Changes

- Documents the main `0.2.0` additions: crawl and ingest APIs, crawler caching, `CloudflareCrawler`, `PostgreSQLStore`, and `EmbeddingNVIDIA`.
- Calls out the compatibility note for `CrawlScope.include_patterns` and `CrawlScope.exclude_patterns`: string patterns now use one glob-style syntax across crawlers, and regex behavior requires compiled `re.Pattern` objects.

## Internal Changes

- Drops a stale dev-only `griffe` constraint. `great-docs` now supplies its compatible `griffe` dependency.

## Testing

- `uv sync --all-extras`
- `uv sync --all-extras --refresh-package great-docs`
- `./.venv/bin/task format`
- `./.venv/bin/task format_check`
- `./.venv/bin/task lint_check`
- `./.venv/bin/task tests`
- `./.venv/bin/task docs_build`

`./.venv/bin/task check` and standalone `./.venv/bin/task types_check` were interrupted because the local `pyright` process produced no diagnostics and did not complete after several minutes.
